### PR TITLE
Global Turntable Configuration

### DIFF
--- a/Vinyl/Turntable.swift
+++ b/Vinyl/Turntable.swift
@@ -19,20 +19,22 @@ typealias RequestCompletionHandler =  (NSData?, NSURLResponse?, NSError?) -> Voi
 public final class Turntable: NSURLSession {
     
     var errorHandler: ErrorHandler = DefaultErrorHandler()
-    private let turntableConfiguration: TurntableConfiguration
+    static var configuration = TurntableConfiguration()
+
     private let player: Player
     
-    public init(vinyl: Vinyl, turntableConfiguration: TurntableConfiguration) {
+    public init(vinyl: Vinyl, turntableConfiguration: TurntableConfiguration? = nil) {
         
-        let trackMatchers = turntableConfiguration.trackMatchersForVinyl(vinyl)
+        let configuration = turntableConfiguration ?? Turntable.configuration
+        let trackMatchers = configuration.trackMatchersForVinyl(vinyl)
         
         self.player = Player(vinyl: vinyl, trackMatchers: trackMatchers)
-        self.turntableConfiguration = turntableConfiguration
+        Turntable.configuration = configuration
         
         super.init()
     }
     
-    public convenience init(cassetteName: String, bundle: NSBundle = testingBundle(), turntableConfiguration: TurntableConfiguration = TurntableConfiguration()) {
+    public convenience init(cassetteName: String, bundle: NSBundle = testingBundle(), turntableConfiguration: TurntableConfiguration? = nil) {
         
         guard let cassette: [String: AnyObject] = loadJSON(bundle, fileName: cassetteName) else {
             fatalError("💣 Cassette file \"\(cassetteName)\" not found 😩")
@@ -71,7 +73,7 @@ public final class Turntable: NSURLSession {
             return try playVinyl(request, completionHandler: completionHandler)
         }
         catch Error.TrackNotFound {
-            errorHandler.handleTrackNotFound(request, playTracksUniquely: turntableConfiguration.playTracksUniquely)
+            errorHandler.handleTrackNotFound(request, playTracksUniquely: Turntable.configuration.playTracksUniquely)
         }
         catch {
             errorHandler.handleUnknownError()

--- a/VinylTests/TurntableTests.swift
+++ b/VinylTests/TurntableTests.swift
@@ -154,6 +154,35 @@ class TurntableTests: XCTestCase {
         turnatable.dataTaskWithRequest(request2, completionHandler: checker).resume()
     }
     
+    func test_GlobalConfigurationIsUsed_When_InputConfigurationIsNil() {
+        
+        let expectation = self.expectationWithDescription("Expected Global Configuration to be used")
+        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+
+        let body = "Hello world".dataUsingEncoding(NSUTF8StringEncoding)
+        let requestToBeSent = NSMutableURLRequest(URL: NSURL(string: "http://api.test1.com")!)
+        requestToBeSent.HTTPBody = body
+        
+        let HTTPResponse = NSHTTPURLResponse(URL: NSURL(string: "http://feelGoodINC")!, MIMEType: nil, expectedContentLength: 0, textEncodingName: nil)
+        let response = Response(urlResponse: HTTPResponse, body: body, error: nil)
+        let mappingRequest = NSMutableURLRequest()
+        mappingRequest.HTTPBody = body
+        
+        let track = Track(request: mappingRequest, response: response)
+
+        let configuration = TurntableConfiguration(matchingStrategy: .RequestAttributes(types: [.Body], playTracksUniquely: true))
+        Turntable.configuration = configuration
+
+        let turnatable = Turntable(vinyl: Vinyl(tracks: [track]))        
+        
+        turnatable.dataTaskWithRequest(requestToBeSent) { (data, response, anError) in
+            
+            XCTAssertFalse(requestToBeSent.URL == response?.URL)
+            XCTAssertTrue(requestToBeSent.HTTPBody == data)
+            expectation.fulfill()
+        }.resume()
+    }
+    
     //MARK: Aux methods
     
     private func singleCallTest(turnatable: Turntable) {


### PR DESCRIPTION
@dmcrodrigues @SandroMachado let me know if this feels right. In a test suit, I would image that you would just set up once the configuration Globally for example on a `setUp` method. But on the other this doesn't feel completly right... :-1: 

What I think it would make more sense is the previous idea:

```swift
class Tests: XCTestCase {

   let turntable: Turntable =  // Turntable with a given config

   func test_() {
      turntable.loadVinyl(...) // vinyl name
      turntable.loadCassette(...) // cassette name
      turntable.loadVinyl(...) // array of tracks
   }
}
```