### PR TITLE
Allow error Track to be created without NSHTTPURLResponse

### DIFF
--- a/Vinyl/Response.swift
+++ b/Vinyl/Response.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 struct Response {
-    let urlResponse: NSHTTPURLResponse
+    let urlResponse: NSHTTPURLResponse?
     let body: NSData?
     let error: NSError?
     
-    init(urlResponse: NSHTTPURLResponse, body: NSData? = nil, error: NSError? = nil) {
+    init(urlResponse: NSHTTPURLResponse?, body: NSData? = nil, error: NSError? = nil) {
         self.urlResponse = urlResponse
         self.body = body
         self.error = error
@@ -48,7 +48,7 @@ extension Response: Hashable {
         let body = self.body ?? ""
         let error = self.error ?? ""
         
-        return "\(urlResponse.hashValue):\((body)):\(error)".hashValue
+        return "\(urlResponse?.hashValue):\((body)):\(error)".hashValue
     }
     
 }

--- a/Vinyl/Track.swift
+++ b/Vinyl/Track.swift
@@ -26,7 +26,7 @@ public struct Track {
         
         self.response = response
         
-        let urlString = response.urlResponse.URL?.absoluteString
+        let urlString = response.urlResponse?.URL?.absoluteString
         let url = NSURL(string: urlString!)!
         
         self.request = NSURLRequest(URL: url)
@@ -89,6 +89,13 @@ public struct TrackFactory {
     public static func createBadTrack(url: NSURL, statusCode: Int, error: NSError? = nil, headers: HTTPHeaders = [:]) -> Track {
         
         return createTrack(url, statusCode: statusCode, body: nil, error: error, headers: headers)
+    }
+
+    public static func createErrorTrack(url: NSURL, error: NSError) -> Track {
+
+        let request = NSURLRequest(URL: url)
+        let response = Response(urlResponse: nil, body: nil, error: error)
+        return Track(request: request, response: response)
     }
     
     public static func createValidTrack(url: NSURL, body: NSData? = nil, headers: HTTPHeaders = [:]) -> Track {

--- a/VinylTests/TrackTests.swift
+++ b/VinylTests/TrackTests.swift
@@ -14,8 +14,8 @@ class TrackTests: XCTestCase {
     func testProperties() {
         property("Bad tracks contain no body") <- forAllNoShrink(urlStringGen) { url in
             let track = TrackFactory.createBadTrack(NSURL(string: url)!, statusCode: 400)
-            return track.response.urlResponse.statusCode == 400
-                && track.response.urlResponse.URL?.absoluteString == url
+            return track.response.urlResponse?.statusCode == 400
+                && track.response.urlResponse?.URL?.absoluteString == url
                 && track.request.URL?.absoluteString == url
                 && track.response.body == nil
         }
@@ -25,9 +25,21 @@ class TrackTests: XCTestCase {
                 let error = NSError(domain: domain, code: code.getPositive, userInfo: nil)
                 let track = TrackFactory.createBadTrack(NSURL(string: url)!, statusCode: code.getPositive, error: error)
                 
-                return track.response.urlResponse.statusCode == code.getPositive
+                return track.response.urlResponse?.statusCode == code.getPositive
                     && track.response.error == error
-                    && track.response.urlResponse.URL?.absoluteString == url
+                    && track.response.urlResponse?.URL?.absoluteString == url
+                    && track.request.URL?.absoluteString == url
+                    && track.response.body == nil
+            }
+        }
+
+        property("Error tracks created without a status code") <- forAllNoShrink(urlStringGen) { url in
+            return forAll { (domain : String, code : Positive<Int>) in
+                let error = NSError(domain: domain, code: code.getPositive, userInfo: nil)
+                let track = TrackFactory.createErrorTrack(NSURL(string: url)!, error: error)
+
+                return track.response.urlResponse == .None
+                    && track.response.error == error
                     && track.request.URL?.absoluteString == url
                     && track.response.body == nil
             }
@@ -84,9 +96,9 @@ class TrackTests: XCTestCase {
 
 func isValidTrack(track: Track, data: NSData, headers: HTTPHeaders, url: String) -> Bool {
     
-    return track.response.urlResponse.statusCode == 200
+    return track.response.urlResponse?.statusCode == 200
         && track.response.body!.isEqualToData(data)
-        && track.response.urlResponse.allHeaderFields as! HTTPHeaders == headers
-        && track.response.urlResponse.URL?.absoluteString == url
+        && track.response.urlResponse?.allHeaderFields as! HTTPHeaders == headers
+        && track.response.urlResponse?.URL?.absoluteString == url
         && track.request.URL?.absoluteString == url
 }

--- a/VinylTests/TurntableTests.swift
+++ b/VinylTests/TurntableTests.swift
@@ -312,11 +312,11 @@ class TurntableTests: XCTestCase {
                 
                 XCTAssertTrue(httpResponse.statusCode == 200)
                 
-                if let responseHeaders = httpResponse.allHeaderFields as? HTTPHeaders, let originalHeaders = track.response.urlResponse.allHeaderFields as? HTTPHeaders {
+                if let responseHeaders = httpResponse.allHeaderFields as? HTTPHeaders, let originalHeaders = track.response.urlResponse?.allHeaderFields as? HTTPHeaders {
                     XCTAssertTrue(responseHeaders == originalHeaders)
                 }
                 
-                XCTAssertTrue(httpResponse.URL == track.response.urlResponse.URL)
+                XCTAssertTrue(httpResponse.URL == track.response.urlResponse?.URL)
                 
                 tracks.removeAtIndex(tracks.indexOf(track)!)
             }


### PR DESCRIPTION
This is my attempt at fixing #61.

It should allow a pure error response to be triggered. The possibly controversial change would be that I added yet another new `TrackFactory` static method called `createErrorTrack`.

I created this one since all it is meant to accept is the `NSURL` of the request and the `NSError` it will provide in response. This method makes that explicit.