### PR TITLE
Allow Turntable to be initialized with default config

### DIFF
--- a/Vinyl/Turntable.swift
+++ b/Vinyl/Turntable.swift
@@ -35,7 +35,7 @@ public final class Turntable: NSURLSession {
         super.init()
     }
     
-    public convenience init(vinyl: Vinyl, turntableConfiguration: TurntableConfiguration, delegateQueue: NSOperationQueue? = nil) {
+    public convenience init(vinyl: Vinyl, turntableConfiguration: TurntableConfiguration = TurntableConfiguration(), delegateQueue: NSOperationQueue? = nil) {
         
         self.init(configuration: turntableConfiguration, delegateQueue: delegateQueue)
         player = Turntable.createPlayer(vinyl, configuration: turntableConfiguration)


### PR DESCRIPTION
Most of the other Turntable initializers provide this convenience. Added it to this initializer as well.

(Discovered while working on #61 and #62)

If you [look at the example in the comments](https://github.com/Velhotes/Vinyl/issues/61#issuecomment-226303344) of #61:

```
func testMocked() {
    let expectation = self.expectationWithDescription(#function)
    defer { self.waitForExpectationsWithTimeout(50.0, handler: nil) }

    let url = NSURL(string: "http://dfsdfhttpbin.org/hidden-basic-auth/:user/:passwd")!
    let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorDNSLookupFailed, userInfo: nil)
    let track = [TrackFactory.createBadTrack(url, statusCode: 400, error: error)]
    let vinyl = Vinyl(tracks: track)
    let turntable = Turntable(vinyl: vinyl)

    turntable.dataTaskWithURL(url) { (data, response, error) in
        XCTAssertNil(data)
        XCTAssertNil(response)
        XCTAssertNotNil(error)
        print(error)
        expectation.fulfill()
    }.resume()
}
```

That `let turntable = Turntable(vinyl: vinyl)` is only possible with this change.