### PR TITLE
Migrated to Swift 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,7 @@ playground.xcworkspace
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
 # Carthage/Checkouts
 
-Carthage/Build
+Carthage/
 
 # fastlane
 #

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "Carthage/Checkouts/SwiftCheck"]
-	path = Carthage/Checkouts/SwiftCheck
-	url = https://github.com/typelift/SwiftCheck.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: objective-c
-osx_image: xcode7.3
+osx_image: xcode8.2
 env:
   matrix:
     - PLATFORM="iOS"
     - PLATFORM="Mac"
     - PLATFORM="tvOS"
-install:
-  - git submodule update --init --recursive
 script:
   - make $PLATFORM
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ script:
   - make $PLATFORM
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+before_script:
+  - carthage bootstrap
 before_deploy:
   - carthage build --no-skip-current
   - carthage archive Vinyl

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "typelift/SwiftCheck" "v0.6.1"
+github "typelift/SwiftCheck" "0.7.2"

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 all: iOS Mac tvOS
 
 iOS:
-	set -o pipefail && xcodebuild test -project Vinyl.xcodeproj -scheme Vinyl-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6s' -enableCodeCoverage YES | xcpretty
+	set -o pipefail && xcodebuild test -project Vinyl.xcodeproj -scheme Vinyl-iOS -destination "platform=iOS Simulator,name=iPhone 6" -enableCodeCoverage YES | xcpretty
 
 Mac:
-	set -o pipefail && xcodebuild test -project Vinyl.xcodeproj -scheme Vinyl-Mac | xcpretty
+	set -o pipefail && xcodebuild test -project Vinyl.xcodeproj -scheme Vinyl-Mac -destination "platform=macOS" | xcpretty
 
 tvOS:
-	set -o pipefail && xcodebuild test -project Vinyl.xcodeproj -scheme Vinyl-tvOS -sdk appletvsimulator -destination "platform=tvOS Simulator,name=Apple TV 1080p" | xcpretty
+	set -o pipefail && xcodebuild test -project Vinyl.xcodeproj -scheme Vinyl-tvOS -destination "platform=tvOS Simulator,name=Apple TV 1080p" | xcpretty

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: iOS Mac tvOS
 
 iOS:
-	set -o pipefail && xcodebuild test -project Vinyl.xcodeproj -scheme Vinyl-iOS -destination "platform=iOS Simulator,name=iPhone 6" -enableCodeCoverage YES | xcpretty
+	set -o pipefail && xcodebuild test -project Vinyl.xcodeproj -scheme Vinyl-iOS -destination "platform=iOS Simulator,name=iPhone 7,OS=10.1" -enableCodeCoverage YES | xcpretty
 
 Mac:
 	set -o pipefail && xcodebuild test -project Vinyl.xcodeproj -scheme Vinyl-Mac -destination "platform=macOS" | xcpretty

--- a/README.md
+++ b/README.md
@@ -84,23 +84,23 @@ enum RequestMatcherType {
 In practise it would look like this:
 
 ```swift
-let matching = .requestAttributes(types: [.body, .query], playTracksUniquely: true)
-let configuration = TurntableConfiguration( matchingStrategy:  matching)
-let turntable = Turntable( vinylName: "vinyl_simple", configuration: configuration)
+let matching = MatchingStrategy.requestAttributes(types: [.body, .query], playTracksUniquely: true)
+let configuration = TurntableConfiguration(matchingStrategy:  matching)
+let turntable = Turntable(vinylName: "vinyl_simple", configuration: configuration)
 ```
 In this case we are matching by `.body` and `.query`. We also provide a way of making sure each track is only played once (or not), by setting the `playTracksUniquely` accordingly. 
 
 If the mapping approach is not desirable, you can make it behave like a queue: the first request will match the first response in the array and so on:
 
 ```swift
-let matching = .trackOrder
-let configuration = TurntableConfiguration( matchingStrategy:  matching)
-let turntable = Turntable( vinylName: "vinyl_simple", configuration: configuration)
+let matching = MatchingStrategy.trackOrder
+let configuration = TurntableConfiguration(matchingStrategy:  matching)
+let turntable = Turntable(vinylName: "vinyl_simple", configuration: configuration)
 ```
 We also allow creating a track by hand, instead of relying on a JSON file:
 
 ```swift
-let track = TrackFactory.createValidTrack(URL(string: "http://feelGoodINC.com")!, body: data, headers: headers)
+let track = TrackFactory.createValidTrack(url: URL(string: "http://feelGoodINC.com")!, body: data, headers: headers)
 
 let vinyl = Vinyl(tracks: [track])
 let turntable = Turntable(vinyl: vinyl, configuration: configuration)
@@ -110,17 +110,17 @@ If you have a custom configuration that you would like to see shared among your 
 
 ```swift
 class FooTests: XCTestCase {
-   let turntable = Turntable(configuration: TurntableConfiguration( matchingStrategy:  .trackOrder))
+    let turntable = Turntable(configuration: TurntableConfiguration(matchingStrategy: .trackOrder))
 
-   func test_1() {
-    turntable.loadVinyl("vinyl_1")
-    // Use the turntable
-   }
+    func test_1() {
+       turntable.loadVinyl("vinyl_1")
+       // Use the turntable
+    }
 
-   func test_2() {
-    turntable.loadVinyl("vinyl_1")
-    // Use the turntable
-   }
+    func test_2() {
+       turntable.loadVinyl("vinyl_1")
+       // Use the turntable
+    }
 }
 ```
 
@@ -132,9 +132,9 @@ Instead of using the [default manager](https://github.com/Alamofire/Alamofire/bl
 
 ```swift
 public init?(
-        session: URLSession,
-        delegate: SessionDelegate,
-        serverTrustPolicyManager: ServerTrustPolicyManager? = nil)
+    session: URLSession,
+    delegate: SessionDelegate,
+    serverTrustPolicyManager: ServerTrustPolicyManager? = nil)
     {
         guard delegate === session.delegate else { return nil }
 
@@ -149,12 +149,11 @@ Your network layer, could then be in the form of:
 
 ```swift
 class Network {
-  private let manager: SessionManager
+    private let manager: SessionManager
   
-  init(session: URLSession) {
-  
-    self.manager = SessionManager(session: session, delegate: SessionDelegate())
-  }
+    init(session: URLSession) {
+        self.manager = SessionManager(session: session, delegate: SessionDelegate())
+    }
 }
 ```
 
@@ -186,18 +185,18 @@ There are 3 recording modes:
 * `.missingVinyl` - will record a new Vinyl if the named Vinyl does not exist. This is the default mode.
 * `.missingTracks` - will record new Tracks to an existing Vinyl where the Track is not found.
 
-Both `.missingVinyl` and `.missingTracks` allow you to specify a `recordingPath` for where to save the recordings. If the the path is not provided (`.nil`) then the default path is current test target's Resource Bundle, which is also the default location from which Vinyl's are loaded.
+Both `.missingVinyl` and `.missingTracks` allow you to specify a `recordingPath` for where to save the recordings. If the path is not provided (`nil`) then the default path is current test target's Resource Bundle, which is also the default location from which Vinyl's are loaded.
 
 #### A simple example
 
 ```swift
-let recordingMode = .missingVinyl(recordingPath: nil)
-let configuration = TurntableConfiguration(recordingMode:  recordingMode)
+let recordingMode = RecordingMode.missingVinyl(recordingPath: nil)
+let configuration = TurntableConfiguration(recordingMode: recordingMode)
 let turntable = Turntable(vinylName: "new_vinyl", configuration: configuration)
 let request = URLRequest(url: URL(string: "http://api.test.com")!)
  
 turntable.dataTask(with: request) { (data, response, anError) in
- // Assert your expectations    
+    // Assert your expectations    
 }.resume()
 ```
 
@@ -205,7 +204,7 @@ The `recordingMode` in the example above is actually the default, but it's shown
 
 Recordings are saved either when the `Turntable` is deinitialized or you can explicitly call `turntable.stopRecording()` which will persist the recorded data.
 
-You can provide a `URLSession` for a `Turntable` to use for making network requests: 
+You can provide a `URLSession` for a `Turntable` to use for making network requests:
 
 `let turntable = Turntable(vinylName: "new_vinyl", configuration: configuration, urlSession: aSession)`
 

--- a/README.md
+++ b/README.md
@@ -177,11 +177,43 @@ let turntable = Turntable(cassetteName: "dvr_single")
 
 That way you won't have to throw anything away.
 
+## Recording
+
+You can also use Vinyl to record requests and responses from the network to use for future testing. This is an easy way to create Vinyls and Tracks automatically with genuine data rather than creating them manually.
+
+There are 3 recording modes:
+* `.none` - recording is disabled.
+* `.missingVinyl` - will record a new Vinyl if the named Vinyl does not exist. This is the default mode.
+* `.missingTracks` - will record new Tracks to an existing Vinyl where the Track is not found.
+
+Both `.missingVinyl` and `.missingTracks` allow you to specify a `recordingPath` for where to save the recordings. If the the path is not provided (`.nil`) then the default path is current test target's Resource Bundle, which is also the default location from which Vinyl's are loaded.
+
+#### A simple example
+
+```swift
+let recordingMode = .missingVinyl(recordingPath: nil)
+let configuration = TurntableConfiguration(recordingMode:  recordingMode)
+let turntable = Turntable(vinylName: "new_vinyl", configuration: configuration)
+let request = URLRequest(url: URL(string: "http://api.test.com")!)
+ 
+turntable.dataTask(with: request) { (data, response, anError) in
+ // Assert your expectations    
+}.resume()
+```
+
+The `recordingMode` in the example above is actually the default, but it's shown explicitly to make it clearer. With the above configuration, if "new_vinyl.json" does't exist it is created and the request will be made over the network. Both the request and response will be recorded.
+
+Recordings are saved either when the `Turntable` is deinitialized or you can explicitly call `turntable.stopRecording()` which will persist the recorded data.
+
+You can provide a `URLSession` for a `Turntable` to use for making network requests: 
+
+`let turntable = Turntable(vinylName: "new_vinyl", configuration: configuration, urlSession: aSession)`
+
+If no `URLSession` is provided, it defaults to `URLSession.shared`.
+
 ## Current Status
 
-The current version ([0.9](https://github.com/Velhotes/Vinyl/releases/tag/0.9.0)) is currently being used in a project successfully. This gives us some degree of confidence it will work for you as well. **Nevertheless don't forget this is a pre-release version**. If there is something that isn't working for you, or you are finding its usage cumbersome, please [let us know](https://github.com/Velhotes/Vinyl/issues/new). 
-
-For the 1.0 release, we are planning to have the ability to record requests. In the meantime if you don't have any JSON pre recorded response, you should create your own `Track` manually (either by code, or with a JSON file). 
+The current version ([0.9](https://github.com/Velhotes/Vinyl/releases/tag/0.9.0)) is currently being used in a project successfully. This gives us some degree of confidence it will work for you as well. **Nevertheless don't forget this is a pre-release version**. If there is something that isn't working for you, or you are finding its usage cumbersome, please [let us know](https://github.com/Velhotes/Vinyl/issues/new).  
 
 ## Roadmap
 

--- a/Vinyl.xcodeproj/project.pbxproj
+++ b/Vinyl.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		4CC9F3841E047BF3003C5BB4 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CC9F3831E047BF3003C5BB4 /* SwiftCheck.framework */; };
 		4CC9F3861E047BFD003C5BB4 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CC9F3851E047BFD003C5BB4 /* SwiftCheck.framework */; };
 		4CC9F3881E047C08003C5BB4 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CC9F3871E047C08003C5BB4 /* SwiftCheck.framework */; };
+		4CD17A9A1E09504D00BBED48 /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4CC9F3831E047BF3003C5BB4 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		4CD17A9C1E09506D00BBED48 /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4CC9F3851E047BFD003C5BB4 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		4CD17A9E1E09508000BBED48 /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4CC9F3871E047C08003C5BB4 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4CD295DC1D57541A00B6D705 /* Recorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD295DB1D57541A00B6D705 /* Recorder.swift */; };
 		4CD295DD1D57541A00B6D705 /* Recorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD295DB1D57541A00B6D705 /* Recorder.swift */; };
 		4CD295DE1D57541A00B6D705 /* Recorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD295DB1D57541A00B6D705 /* Recorder.swift */; };
@@ -142,6 +145,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				4CD17A9C1E09506D00BBED48 /* SwiftCheck.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -151,6 +155,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				4CD17A9E1E09508000BBED48 /* SwiftCheck.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -160,6 +165,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				4CD17A9A1E09504D00BBED48 /* SwiftCheck.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Vinyl.xcodeproj/project.pbxproj
+++ b/Vinyl.xcodeproj/project.pbxproj
@@ -822,6 +822,7 @@
 				PRODUCT_NAME = Vinyl;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -843,6 +844,7 @@
 				PRODUCT_NAME = Vinyl;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -861,6 +863,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = velhotes.VinylTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -879,6 +882,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = velhotes.VinylTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -897,6 +901,7 @@
 				PRODUCT_NAME = Vinyl;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.1;
 			};
@@ -917,6 +922,7 @@
 				PRODUCT_NAME = Vinyl;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.1;
 			};
@@ -934,6 +940,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = velhotes.VinylTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.1;
 			};
 			name = Debug;
@@ -950,6 +957,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = velhotes.VinylTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 3.0;
 				TVOS_DEPLOYMENT_TARGET = 9.1;
 			};
 			name = Release;

--- a/Vinyl.xcodeproj/project.pbxproj
+++ b/Vinyl.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4CC9F3841E047BF3003C5BB4 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CC9F3831E047BF3003C5BB4 /* SwiftCheck.framework */; };
+		4CC9F3861E047BFD003C5BB4 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CC9F3851E047BFD003C5BB4 /* SwiftCheck.framework */; };
+		4CC9F3881E047C08003C5BB4 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CC9F3871E047C08003C5BB4 /* SwiftCheck.framework */; };
 		4CD295DC1D57541A00B6D705 /* Recorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD295DB1D57541A00B6D705 /* Recorder.swift */; };
 		4CD295DD1D57541A00B6D705 /* Recorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD295DB1D57541A00B6D705 /* Recorder.swift */; };
 		4CD295DE1D57541A00B6D705 /* Recorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CD295DB1D57541A00B6D705 /* Recorder.swift */; };
@@ -16,13 +19,11 @@
 		7D7171AA1CABE6440080C1F4 /* URLSessionTaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE666A51CAB49DA00ED063D /* URLSessionTaskType.swift */; };
 		7D7171AE1CABE6450080C1F4 /* URLSessionTaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE666A51CAB49DA00ED063D /* URLSessionTaskType.swift */; };
 		7DBD4C891C79CA24008C5487 /* Vinyl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DBD4C7F1C79CA24008C5487 /* Vinyl.framework */; };
-		7DBD4C961C79CAB0008C5487 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82D8B7811C78FE2400D8E037 /* SwiftCheck.framework */; };
 		7DBD4C971C79CACE008C5487 /* MockedTrackedNotFoundErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7995DC61C75F75400E1D905 /* MockedTrackedNotFoundErrorHandler.swift */; };
 		7DBD4C981C79CACE008C5487 /* TurntableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72AD2F31C6E4B7800E11612 /* TurntableTests.swift */; };
 		7DBD4C991C79CACE008C5487 /* RequestMatcherRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC570501C72ACA100BA1458 /* RequestMatcherRegistryTests.swift */; };
 		7DBD4C9A1C79CACE008C5487 /* TrackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886201C73FBBF002DBB2C /* TrackTests.swift */; };
 		7DBD4C9B1C79CACE008C5487 /* Arbitrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D8B7731C78E3FF00D8E037 /* Arbitrary.swift */; };
-		7DBD4C9F1C79CB06008C5487 /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 82D8B7811C78FE2400D8E037 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7DBD4CA01C79CB18008C5487 /* dvr_multiple.json in Resources */ = {isa = PBXBuildFile; fileRef = C70886341C74D470002DBB2C /* dvr_multiple.json */; };
 		7DBD4CA11C79CB18008C5487 /* dvr_single.json in Resources */ = {isa = PBXBuildFile; fileRef = C70886351C74D470002DBB2C /* dvr_single.json */; };
 		7DBD4CA21C79CB18008C5487 /* vinyl_multiple.json in Resources */ = {isa = PBXBuildFile; fileRef = C70886301C74D452002DBB2C /* vinyl_multiple.json */; };
@@ -30,10 +31,10 @@
 		7DBD4CB31C79CC4D008C5487 /* Vinyl.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DBD4CA91C79CC4C008C5487 /* Vinyl.framework */; };
 		7DBD4CC21C79CCE2008C5487 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7995DC11C75F38F00E1D905 /* ErrorHandler.swift */; };
 		7DBD4CC31C79CCE2008C5487 /* FuncComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886141C735136002DBB2C /* FuncComposition.swift */; };
-		7DBD4CC41C79CCE2008C5487 /* NSURLQueryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886111C7346CF002DBB2C /* NSURLQueryItem.swift */; };
-		7DBD4CC51C79CCE2008C5487 /* NSURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886161C737684002DBB2C /* NSURLRequest.swift */; };
+		7DBD4CC41C79CCE2008C5487 /* URLQueryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886111C7346CF002DBB2C /* URLQueryItem.swift */; };
+		7DBD4CC51C79CCE2008C5487 /* URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886161C737684002DBB2C /* URLRequest.swift */; };
 		7DBD4CC61C79CCE2008C5487 /* SequenceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C708861A1C737C1B002DBB2C /* SequenceType.swift */; };
-		7DBD4CC71C79CCE2008C5487 /* NSBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7995DCD1C7724F700E1D905 /* NSBundle.swift */; };
+		7DBD4CC71C79CCE2008C5487 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7995DCD1C7724F700E1D905 /* Bundle.swift */; };
 		7DBD4CC81C79CCE2008C5487 /* EncodingDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72AD2F11C6E48B500E11612 /* EncodingDecoding.swift */; };
 		7DBD4CC91C79CCE2008C5487 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72AD2EB1C6E275000E11612 /* JSONHelper.swift */; };
 		7DBD4CCA1C79CCE2008C5487 /* Turntable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75D79221C6E0E9D004B92A9 /* Turntable.swift */; };
@@ -47,10 +48,10 @@
 		7DBD4CD21C79CCE2008C5487 /* RequestMatcherRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D48F0D21C7159F10044DC32 /* RequestMatcherRegistry.swift */; };
 		7DBD4CD31C79CCF4008C5487 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7995DC11C75F38F00E1D905 /* ErrorHandler.swift */; };
 		7DBD4CD41C79CCF4008C5487 /* FuncComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886141C735136002DBB2C /* FuncComposition.swift */; };
-		7DBD4CD51C79CCF4008C5487 /* NSURLQueryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886111C7346CF002DBB2C /* NSURLQueryItem.swift */; };
-		7DBD4CD61C79CCF4008C5487 /* NSURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886161C737684002DBB2C /* NSURLRequest.swift */; };
+		7DBD4CD51C79CCF4008C5487 /* URLQueryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886111C7346CF002DBB2C /* URLQueryItem.swift */; };
+		7DBD4CD61C79CCF4008C5487 /* URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886161C737684002DBB2C /* URLRequest.swift */; };
 		7DBD4CD71C79CCF4008C5487 /* SequenceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C708861A1C737C1B002DBB2C /* SequenceType.swift */; };
-		7DBD4CD81C79CCF4008C5487 /* NSBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7995DCD1C7724F700E1D905 /* NSBundle.swift */; };
+		7DBD4CD81C79CCF4008C5487 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7995DCD1C7724F700E1D905 /* Bundle.swift */; };
 		7DBD4CD91C79CCF4008C5487 /* EncodingDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72AD2F11C6E48B500E11612 /* EncodingDecoding.swift */; };
 		7DBD4CDA1C79CCF4008C5487 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72AD2EB1C6E275000E11612 /* JSONHelper.swift */; };
 		7DBD4CDB1C79CCF4008C5487 /* Turntable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75D79221C6E0E9D004B92A9 /* Turntable.swift */; };
@@ -64,10 +65,10 @@
 		7DBD4CE31C79CCF4008C5487 /* RequestMatcherRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D48F0D21C7159F10044DC32 /* RequestMatcherRegistry.swift */; };
 		7DBD4CE41C79CCFA008C5487 /* ErrorHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7995DC11C75F38F00E1D905 /* ErrorHandler.swift */; };
 		7DBD4CE51C79CCFA008C5487 /* FuncComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886141C735136002DBB2C /* FuncComposition.swift */; };
-		7DBD4CE61C79CCFA008C5487 /* NSURLQueryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886111C7346CF002DBB2C /* NSURLQueryItem.swift */; };
-		7DBD4CE71C79CCFA008C5487 /* NSURLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886161C737684002DBB2C /* NSURLRequest.swift */; };
+		7DBD4CE61C79CCFA008C5487 /* URLQueryItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886111C7346CF002DBB2C /* URLQueryItem.swift */; };
+		7DBD4CE71C79CCFA008C5487 /* URLRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886161C737684002DBB2C /* URLRequest.swift */; };
 		7DBD4CE81C79CCFA008C5487 /* SequenceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C708861A1C737C1B002DBB2C /* SequenceType.swift */; };
-		7DBD4CE91C79CCFA008C5487 /* NSBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7995DCD1C7724F700E1D905 /* NSBundle.swift */; };
+		7DBD4CE91C79CCFA008C5487 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7995DCD1C7724F700E1D905 /* Bundle.swift */; };
 		7DBD4CEA1C79CCFA008C5487 /* EncodingDecoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72AD2F11C6E48B500E11612 /* EncodingDecoding.swift */; };
 		7DBD4CEB1C79CCFA008C5487 /* JSONHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72AD2EB1C6E275000E11612 /* JSONHelper.swift */; };
 		7DBD4CEC1C79CCFA008C5487 /* Turntable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75D79221C6E0E9D004B92A9 /* Turntable.swift */; };
@@ -89,8 +90,6 @@
 		7DBD4CFE1C79CD6B008C5487 /* RequestMatcherRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DC570501C72ACA100BA1458 /* RequestMatcherRegistryTests.swift */; };
 		7DBD4CFF1C79CD6B008C5487 /* TrackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C70886201C73FBBF002DBB2C /* TrackTests.swift */; };
 		7DBD4D001C79CD6B008C5487 /* Arbitrary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D8B7731C78E3FF00D8E037 /* Arbitrary.swift */; };
-		7DBD4D011C79CD7D008C5487 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82D8B7811C78FE2400D8E037 /* SwiftCheck.framework */; };
-		7DBD4D051C79CD97008C5487 /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 82D8B7891C78FE2400D8E037 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7DBD4D061C79CDAF008C5487 /* dvr_multiple.json in Resources */ = {isa = PBXBuildFile; fileRef = C70886341C74D470002DBB2C /* dvr_multiple.json */; };
 		7DBD4D071C79CDAF008C5487 /* dvr_single.json in Resources */ = {isa = PBXBuildFile; fileRef = C70886351C74D470002DBB2C /* dvr_single.json */; };
 		7DBD4D081C79CDAF008C5487 /* vinyl_multiple.json in Resources */ = {isa = PBXBuildFile; fileRef = C70886301C74D452002DBB2C /* vinyl_multiple.json */; };
@@ -99,8 +98,6 @@
 		7DBD4D0C1C79CEEB008C5487 /* Vinyl.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DBD4D0A1C79CEE6008C5487 /* Vinyl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7DBD4D0D1C79CEED008C5487 /* Vinyl.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DBD4D0A1C79CEE6008C5487 /* Vinyl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7DE666A61CAB49DA00ED063D /* URLSessionTaskType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DE666A51CAB49DA00ED063D /* URLSessionTaskType.swift */; };
-		82D8B78E1C78FE3100D8E037 /* SwiftCheck.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82D8B7851C78FE2400D8E037 /* SwiftCheck.framework */; };
-		82D8B78F1C78FE3800D8E037 /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 82D8B7851C78FE2400D8E037 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C70886321C74D452002DBB2C /* vinyl_multiple.json in Resources */ = {isa = PBXBuildFile; fileRef = C70886301C74D452002DBB2C /* vinyl_multiple.json */; };
 		C70886331C74D452002DBB2C /* vinyl_single.json in Resources */ = {isa = PBXBuildFile; fileRef = C70886311C74D452002DBB2C /* vinyl_single.json */; };
 		C70886361C74D470002DBB2C /* dvr_multiple.json in Resources */ = {isa = PBXBuildFile; fileRef = C70886341C74D470002DBB2C /* dvr_multiple.json */; };
@@ -122,75 +119,12 @@
 			remoteGlobalIDString = 7DBD4C7E1C79CA24008C5487;
 			remoteInfo = "Vinyl-Mac";
 		};
-		7DBD4C9C1C79CADD008C5487 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 82D8B7771C78FE2400D8E037 /* SwiftCheck.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 844FCC8C198B320500EB242A;
-			remoteInfo = SwiftCheck;
-		};
 		7DBD4CB41C79CC4D008C5487 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = C75D78FD1C6DFE30004B92A9 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 7DBD4CA81C79CC4C008C5487;
 			remoteInfo = "Vinyl-tvOS";
-		};
-		7DBD4CF51C79CD52008C5487 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 82D8B7771C78FE2400D8E037 /* SwiftCheck.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 8240CCB01C3A123600EF4D29;
-			remoteInfo = "SwiftCheck-tvOS";
-		};
-		82D8B7801C78FE2400D8E037 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 82D8B7771C78FE2400D8E037 /* SwiftCheck.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 844FCC8D198B320500EB242A;
-			remoteInfo = SwiftCheck;
-		};
-		82D8B7821C78FE2400D8E037 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 82D8B7771C78FE2400D8E037 /* SwiftCheck.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 844FCC98198B320500EB242A;
-			remoteInfo = SwiftCheckTests;
-		};
-		82D8B7841C78FE2400D8E037 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 82D8B7771C78FE2400D8E037 /* SwiftCheck.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 84DF75F81B0BD54600C912B0;
-			remoteInfo = "SwiftCheck-iOS";
-		};
-		82D8B7861C78FE2400D8E037 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 82D8B7771C78FE2400D8E037 /* SwiftCheck.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 84DF76021B0BD54600C912B0;
-			remoteInfo = "SwiftCheck-iOSTests";
-		};
-		82D8B7881C78FE2400D8E037 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 82D8B7771C78FE2400D8E037 /* SwiftCheck.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 8240CCB11C3A123600EF4D29;
-			remoteInfo = "SwiftCheck-tvOS";
-		};
-		82D8B78A1C78FE2400D8E037 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 82D8B7771C78FE2400D8E037 /* SwiftCheck.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 8240CCBA1C3A123700EF4D29;
-			remoteInfo = "SwiftCheck-tvOSTests";
-		};
-		82D8B78C1C78FE2900D8E037 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 82D8B7771C78FE2400D8E037 /* SwiftCheck.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 84DF75F71B0BD54600C912B0;
-			remoteInfo = "SwiftCheck-iOS";
 		};
 		C75D79121C6DFE30004B92A9 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -208,7 +142,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				7DBD4C9F1C79CB06008C5487 /* SwiftCheck.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -218,7 +151,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				7DBD4D051C79CD97008C5487 /* SwiftCheck.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -228,13 +160,15 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				82D8B78F1C78FE3800D8E037 /* SwiftCheck.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		4CC9F3831E047BF3003C5BB4 /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftCheck.framework; path = Carthage/Build/iOS/SwiftCheck.framework; sourceTree = "<group>"; };
+		4CC9F3851E047BFD003C5BB4 /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftCheck.framework; path = Carthage/Build/Mac/SwiftCheck.framework; sourceTree = "<group>"; };
+		4CC9F3871E047C08003C5BB4 /* SwiftCheck.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftCheck.framework; path = Carthage/Build/tvOS/SwiftCheck.framework; sourceTree = "<group>"; };
 		4CD295DB1D57541A00B6D705 /* Recorder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Recorder.swift; sourceTree = "<group>"; };
 		4CD295E21D57545A00B6D705 /* Wax.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Wax.swift; sourceTree = "<group>"; };
 		7D22F3011C75351B00A81608 /* TurntableConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TurntableConfiguration.swift; sourceTree = "<group>"; };
@@ -251,10 +185,9 @@
 		7DC570501C72ACA100BA1458 /* RequestMatcherRegistryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestMatcherRegistryTests.swift; sourceTree = "<group>"; };
 		7DE666A51CAB49DA00ED063D /* URLSessionTaskType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionTaskType.swift; sourceTree = "<group>"; };
 		82D8B7731C78E3FF00D8E037 /* Arbitrary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Arbitrary.swift; sourceTree = "<group>"; };
-		82D8B7771C78FE2400D8E037 /* SwiftCheck.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftCheck.xcodeproj; path = Carthage/Checkouts/SwiftCheck/SwiftCheck.xcodeproj; sourceTree = SOURCE_ROOT; };
-		C70886111C7346CF002DBB2C /* NSURLQueryItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLQueryItem.swift; sourceTree = "<group>"; };
+		C70886111C7346CF002DBB2C /* URLQueryItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLQueryItem.swift; sourceTree = "<group>"; };
 		C70886141C735136002DBB2C /* FuncComposition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FuncComposition.swift; sourceTree = "<group>"; };
-		C70886161C737684002DBB2C /* NSURLRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSURLRequest.swift; sourceTree = "<group>"; };
+		C70886161C737684002DBB2C /* URLRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLRequest.swift; sourceTree = "<group>"; };
 		C708861A1C737C1B002DBB2C /* SequenceType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SequenceType.swift; sourceTree = "<group>"; };
 		C708861C1C738A19002DBB2C /* URLSessionDataTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionDataTask.swift; sourceTree = "<group>"; };
 		C70886201C73FBBF002DBB2C /* TrackTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackTests.swift; sourceTree = "<group>"; };
@@ -273,7 +206,7 @@
 		C75D79221C6E0E9D004B92A9 /* Turntable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Turntable.swift; sourceTree = "<group>"; };
 		C7995DC11C75F38F00E1D905 /* ErrorHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorHandler.swift; sourceTree = "<group>"; };
 		C7995DC61C75F75400E1D905 /* MockedTrackedNotFoundErrorHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockedTrackedNotFoundErrorHandler.swift; sourceTree = "<group>"; };
-		C7995DCD1C7724F700E1D905 /* NSBundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSBundle.swift; sourceTree = "<group>"; };
+		C7995DCD1C7724F700E1D905 /* Bundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		E530E6101C864B3300D9B590 /* URLSessionUploadTask.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionUploadTask.swift; sourceTree = "<group>"; };
 		E530E6171C864E1800D9B590 /* vinyl_upload.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = vinyl_upload.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -290,8 +223,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7DBD4C961C79CAB0008C5487 /* SwiftCheck.framework in Frameworks */,
 				7DBD4C891C79CA24008C5487 /* Vinyl.framework in Frameworks */,
+				4CC9F3861E047BFD003C5BB4 /* SwiftCheck.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -306,8 +239,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7DBD4D011C79CD7D008C5487 /* SwiftCheck.framework in Frameworks */,
 				7DBD4CB31C79CC4D008C5487 /* Vinyl.framework in Frameworks */,
+				4CC9F3881E047C08003C5BB4 /* SwiftCheck.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -322,34 +255,31 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				82D8B78E1C78FE3100D8E037 /* SwiftCheck.framework in Frameworks */,
 				C75D79111C6DFE30004B92A9 /* Vinyl.framework in Frameworks */,
+				4CC9F3841E047BF3003C5BB4 /* SwiftCheck.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		82D8B7781C78FE2400D8E037 /* Products */ = {
+		4CC9F3821E047BF3003C5BB4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				82D8B7811C78FE2400D8E037 /* SwiftCheck.framework */,
-				82D8B7831C78FE2400D8E037 /* SwiftCheckTests.xctest */,
-				82D8B7851C78FE2400D8E037 /* SwiftCheck.framework */,
-				82D8B7871C78FE2400D8E037 /* SwiftCheck-iOSTests.xctest */,
-				82D8B7891C78FE2400D8E037 /* SwiftCheck.framework */,
-				82D8B78B1C78FE2400D8E037 /* SwiftCheck-tvOSTests.xctest */,
+				4CC9F3871E047C08003C5BB4 /* SwiftCheck.framework */,
+				4CC9F3851E047BFD003C5BB4 /* SwiftCheck.framework */,
+				4CC9F3831E047BF3003C5BB4 /* SwiftCheck.framework */,
 			);
-			name = Products;
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		C70886101C7346C8002DBB2C /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				C70886111C7346CF002DBB2C /* NSURLQueryItem.swift */,
-				C70886161C737684002DBB2C /* NSURLRequest.swift */,
+				C70886111C7346CF002DBB2C /* URLQueryItem.swift */,
+				C70886161C737684002DBB2C /* URLRequest.swift */,
 				C708861A1C737C1B002DBB2C /* SequenceType.swift */,
-				C7995DCD1C7724F700E1D905 /* NSBundle.swift */,
+				C7995DCD1C7724F700E1D905 /* Bundle.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -396,6 +326,7 @@
 				C75D79081C6DFE30004B92A9 /* Vinyl */,
 				C75D79141C6DFE30004B92A9 /* VinylTests */,
 				C75D79071C6DFE30004B92A9 /* Products */,
+				4CC9F3821E047BF3003C5BB4 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -448,7 +379,6 @@
 				7DC570501C72ACA100BA1458 /* RequestMatcherRegistryTests.swift */,
 				C70886201C73FBBF002DBB2C /* TrackTests.swift */,
 				82D8B7731C78E3FF00D8E037 /* Arbitrary.swift */,
-				82D8B7771C78FE2400D8E037 /* SwiftCheck.xcodeproj */,
 				C75D79171C6DFE30004B92A9 /* Info.plist */,
 			);
 			path = VinylTests;
@@ -530,7 +460,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				7DBD4C9D1C79CADD008C5487 /* PBXTargetDependency */,
 				7DBD4C8B1C79CA24008C5487 /* PBXTargetDependency */,
 			);
 			name = "Vinyl-MacTests";
@@ -568,7 +497,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				7DBD4CF61C79CD52008C5487 /* PBXTargetDependency */,
 				7DBD4CB51C79CC4D008C5487 /* PBXTargetDependency */,
 			);
 			name = "Vinyl-tvOSTests";
@@ -606,7 +534,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				82D8B78D1C78FE2900D8E037 /* PBXTargetDependency */,
 				C75D79131C6DFE30004B92A9 /* PBXTargetDependency */,
 			);
 			name = "Vinyl-iOSTests";
@@ -621,7 +548,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = Velhotes;
 				TargetAttributes = {
 					7DBD4C7E1C79CA24008C5487 = {
@@ -638,9 +565,12 @@
 					};
 					C75D79051C6DFE30004B92A9 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0820;
 					};
 					C75D790F1C6DFE30004B92A9 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0820;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -654,12 +584,6 @@
 			mainGroup = C75D78FC1C6DFE30004B92A9;
 			productRefGroup = C75D79071C6DFE30004B92A9 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = 82D8B7781C78FE2400D8E037 /* Products */;
-					ProjectRef = 82D8B7771C78FE2400D8E037 /* SwiftCheck.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				C75D79051C6DFE30004B92A9 /* Vinyl-iOS */,
@@ -671,51 +595,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		82D8B7811C78FE2400D8E037 /* SwiftCheck.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = SwiftCheck.framework;
-			remoteRef = 82D8B7801C78FE2400D8E037 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		82D8B7831C78FE2400D8E037 /* SwiftCheckTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = SwiftCheckTests.xctest;
-			remoteRef = 82D8B7821C78FE2400D8E037 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		82D8B7851C78FE2400D8E037 /* SwiftCheck.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = SwiftCheck.framework;
-			remoteRef = 82D8B7841C78FE2400D8E037 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		82D8B7871C78FE2400D8E037 /* SwiftCheck-iOSTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "SwiftCheck-iOSTests.xctest";
-			remoteRef = 82D8B7861C78FE2400D8E037 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		82D8B7891C78FE2400D8E037 /* SwiftCheck.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = SwiftCheck.framework;
-			remoteRef = 82D8B7881C78FE2400D8E037 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		82D8B78B1C78FE2400D8E037 /* SwiftCheck-tvOSTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = "SwiftCheck-tvOSTests.xctest";
-			remoteRef = 82D8B78A1C78FE2400D8E037 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		7DBD4C7D1C79CA24008C5487 /* Resources */ = {
@@ -785,10 +664,10 @@
 				7DBD4CC21C79CCE2008C5487 /* ErrorHandler.swift in Sources */,
 				7DBD4CC31C79CCE2008C5487 /* FuncComposition.swift in Sources */,
 				E530E6121C864B3300D9B590 /* URLSessionUploadTask.swift in Sources */,
-				7DBD4CC41C79CCE2008C5487 /* NSURLQueryItem.swift in Sources */,
-				7DBD4CC51C79CCE2008C5487 /* NSURLRequest.swift in Sources */,
+				7DBD4CC41C79CCE2008C5487 /* URLQueryItem.swift in Sources */,
+				7DBD4CC51C79CCE2008C5487 /* URLRequest.swift in Sources */,
 				7DBD4CC61C79CCE2008C5487 /* SequenceType.swift in Sources */,
-				7DBD4CC71C79CCE2008C5487 /* NSBundle.swift in Sources */,
+				7DBD4CC71C79CCE2008C5487 /* Bundle.swift in Sources */,
 				7DBD4CC81C79CCE2008C5487 /* EncodingDecoding.swift in Sources */,
 				7DBD4CC91C79CCE2008C5487 /* JSONHelper.swift in Sources */,
 				4CD295E41D57545A00B6D705 /* Wax.swift in Sources */,
@@ -825,10 +704,10 @@
 				7DBD4CE41C79CCFA008C5487 /* ErrorHandler.swift in Sources */,
 				7DBD4CE51C79CCFA008C5487 /* FuncComposition.swift in Sources */,
 				E530E6131C864B3300D9B590 /* URLSessionUploadTask.swift in Sources */,
-				7DBD4CE61C79CCFA008C5487 /* NSURLQueryItem.swift in Sources */,
-				7DBD4CE71C79CCFA008C5487 /* NSURLRequest.swift in Sources */,
+				7DBD4CE61C79CCFA008C5487 /* URLQueryItem.swift in Sources */,
+				7DBD4CE71C79CCFA008C5487 /* URLRequest.swift in Sources */,
 				7DBD4CE81C79CCFA008C5487 /* SequenceType.swift in Sources */,
-				7DBD4CE91C79CCFA008C5487 /* NSBundle.swift in Sources */,
+				7DBD4CE91C79CCFA008C5487 /* Bundle.swift in Sources */,
 				7DBD4CEA1C79CCFA008C5487 /* EncodingDecoding.swift in Sources */,
 				7DBD4CEB1C79CCFA008C5487 /* JSONHelper.swift in Sources */,
 				4CD295E51D57545A00B6D705 /* Wax.swift in Sources */,
@@ -865,10 +744,10 @@
 				7DBD4CD31C79CCF4008C5487 /* ErrorHandler.swift in Sources */,
 				7DBD4CD41C79CCF4008C5487 /* FuncComposition.swift in Sources */,
 				E530E6111C864B3300D9B590 /* URLSessionUploadTask.swift in Sources */,
-				7DBD4CD51C79CCF4008C5487 /* NSURLQueryItem.swift in Sources */,
-				7DBD4CD61C79CCF4008C5487 /* NSURLRequest.swift in Sources */,
+				7DBD4CD51C79CCF4008C5487 /* URLQueryItem.swift in Sources */,
+				7DBD4CD61C79CCF4008C5487 /* URLRequest.swift in Sources */,
 				7DBD4CD71C79CCF4008C5487 /* SequenceType.swift in Sources */,
-				7DBD4CD81C79CCF4008C5487 /* NSBundle.swift in Sources */,
+				7DBD4CD81C79CCF4008C5487 /* Bundle.swift in Sources */,
 				7DBD4CD91C79CCF4008C5487 /* EncodingDecoding.swift in Sources */,
 				7DBD4CDA1C79CCF4008C5487 /* JSONHelper.swift in Sources */,
 				4CD295E31D57545A00B6D705 /* Wax.swift in Sources */,
@@ -906,25 +785,10 @@
 			target = 7DBD4C7E1C79CA24008C5487 /* Vinyl-Mac */;
 			targetProxy = 7DBD4C8A1C79CA24008C5487 /* PBXContainerItemProxy */;
 		};
-		7DBD4C9D1C79CADD008C5487 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = SwiftCheck;
-			targetProxy = 7DBD4C9C1C79CADD008C5487 /* PBXContainerItemProxy */;
-		};
 		7DBD4CB51C79CC4D008C5487 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 7DBD4CA81C79CC4C008C5487 /* Vinyl-tvOS */;
 			targetProxy = 7DBD4CB41C79CC4D008C5487 /* PBXContainerItemProxy */;
-		};
-		7DBD4CF61C79CD52008C5487 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "SwiftCheck-tvOS";
-			targetProxy = 7DBD4CF51C79CD52008C5487 /* PBXContainerItemProxy */;
-		};
-		82D8B78D1C78FE2900D8E037 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "SwiftCheck-iOS";
-			targetProxy = 82D8B78C1C78FE2900D8E037 /* PBXContainerItemProxy */;
 		};
 		C75D79131C6DFE30004B92A9 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1015,6 +879,7 @@
 		7DBD4CBB1C79CC4D008C5487 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1034,6 +899,7 @@
 		7DBD4CBC1C79CC4D008C5487 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1096,8 +962,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -1145,8 +1013,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -1166,6 +1036,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1177,6 +1048,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1188,6 +1060,7 @@
 				PRODUCT_NAME = Vinyl;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -1195,6 +1068,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -1205,12 +1079,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = velhotes.Vinyl;
 				PRODUCT_NAME = Vinyl;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
 		C75D791E1C6DFE30004B92A9 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1219,12 +1095,14 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = velhotes.VinylTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		C75D791F1C6DFE30004B92A9 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
@@ -1233,6 +1111,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = velhotes.VinylTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Vinyl.xcodeproj/xcshareddata/xcschemes/Vinyl-Mac.xcscheme
+++ b/Vinyl.xcodeproj/xcshareddata/xcschemes/Vinyl-Mac.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Vinyl.xcodeproj/xcshareddata/xcschemes/Vinyl-iOS.xcscheme
+++ b/Vinyl.xcodeproj/xcshareddata/xcschemes/Vinyl-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Vinyl.xcodeproj/xcshareddata/xcschemes/Vinyl-tvOS.xcscheme
+++ b/Vinyl.xcodeproj/xcshareddata/xcschemes/Vinyl-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0820"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Vinyl/Composition/FuncComposition.swift
+++ b/Vinyl/Composition/FuncComposition.swift
@@ -8,9 +8,14 @@
 
 import Foundation
 
-infix operator ~> { associativity left }
+precedencegroup VinylPrecedenceLeft {
+    associativity: left
+    higherThan: AssignmentPrecedence
+}
 
-func ~> <T, U, V>(f: T -> U, g: U -> V) -> T -> V {
+infix operator ~> : VinylPrecedenceLeft
+
+func ~> <T, U, V>(f: @escaping (T) -> U, g: @escaping (U) -> V) -> (T) -> V {
     
     return { g(f($0)) }
 }

--- a/Vinyl/EncodingDecoding/EncodingDecoding.swift
+++ b/Vinyl/EncodingDecoding/EncodingDecoding.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 // Heavily inspired by Venmo's work on DVR (https://github.com/venmo/DVR).
-func encode(body bodyData: Data?, headers: HTTPHeaders) -> Any? {
+func encode(body: Data?, headers: HTTPHeaders) -> Any? {
     
     guard
-        let body = bodyData,
+        let body = body,
         let contentType = headers["Content-Type"]
         else {
             return nil
@@ -31,9 +31,9 @@ func encode(body bodyData: Data?, headers: HTTPHeaders) -> Any? {
     }
 }
 
-func decode(body bodyData: Any?, headers: HTTPHeaders) -> Data? {
+func decode(body: Any?, headers: HTTPHeaders) -> Data? {
     
-    guard let body = bodyData else { return nil }
+    guard let body = body else { return nil }
     
     guard let contentType = headers["Content-Type"]  else {
         

--- a/Vinyl/EncodingDecoding/EncodingDecoding.swift
+++ b/Vinyl/EncodingDecoding/EncodingDecoding.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 // Heavily inspired by Venmo's work on DVR (https://github.com/venmo/DVR).
-func encodeBody(_ bodyData: Data?, headers: HTTPHeaders) -> AnyObject? {
+func encode(body bodyData: Data?, headers: HTTPHeaders) -> Any? {
     
     guard
         let body = bodyData,
@@ -21,17 +21,17 @@ func encodeBody(_ bodyData: Data?, headers: HTTPHeaders) -> AnyObject? {
     switch contentType {
         
     case _ where contentType.hasPrefix("text/"):
-        return String(data: body, encoding: .utf8) as AnyObject?
+        return String(data: body, encoding: .utf8) as Any?
         
     case _ where contentType.hasPrefix("application/json"):
-        return try! JSONSerialization.jsonObject(with: body, options: []) as AnyObject?
+        return try! JSONSerialization.jsonObject(with: body) as Any?
         
     default:
-        return body.base64EncodedString(options: []) as AnyObject?
+        return body.base64EncodedString(options: []) as Any?
     }
 }
 
-func decodeBody(_ bodyData: Any?, headers: HTTPHeaders) -> Data? {
+func decode(body bodyData: Any?, headers: HTTPHeaders) -> Data? {
     
     guard let body = bodyData else { return nil }
     
@@ -51,7 +51,7 @@ func decodeBody(_ bodyData: Any?, headers: HTTPHeaders) -> Data? {
     }
     
     if contentType.hasPrefix("application/json") {
-        return try? JSONSerialization.data(withJSONObject: body, options: [])
+        return try? JSONSerialization.data(withJSONObject: body)
     }
     
     if let string = body as? String {

--- a/Vinyl/EncodingDecoding/EncodingDecoding.swift
+++ b/Vinyl/EncodingDecoding/EncodingDecoding.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 // Heavily inspired by Venmo's work on DVR (https://github.com/venmo/DVR).
-func encodeBody(bodyData: NSData?, headers: HTTPHeaders) -> AnyObject? {
+func encodeBody(_ bodyData: Data?, headers: HTTPHeaders) -> AnyObject? {
     
     guard
         let body = bodyData,
@@ -21,17 +21,17 @@ func encodeBody(bodyData: NSData?, headers: HTTPHeaders) -> AnyObject? {
     switch contentType {
         
     case _ where contentType.hasPrefix("text/"):
-        return NSString(data: body, encoding: NSUTF8StringEncoding).map (String.init)
+        return String(data: body, encoding: .utf8) as AnyObject?
         
     case _ where contentType.hasPrefix("application/json"):
-        return try? NSJSONSerialization.JSONObjectWithData(body, options: [])
+        return try! JSONSerialization.jsonObject(with: body, options: []) as AnyObject?
         
     default:
-        return body.base64EncodedStringWithOptions([])
+        return body.base64EncodedString(options: []) as AnyObject?
     }
 }
 
-func decodeBody(bodyData: AnyObject?, headers: HTTPHeaders) -> NSData? {
+func decodeBody(_ bodyData: Any?, headers: HTTPHeaders) -> Data? {
     
     guard let body = bodyData else { return nil }
     
@@ -39,23 +39,23 @@ func decodeBody(bodyData: AnyObject?, headers: HTTPHeaders) -> NSData? {
         
         // As last resource, we will check if the bodyData is a string and if so convert it
         if let string = body as? String {
-            return string.dataUsingEncoding(NSUTF8StringEncoding)
+            return string.data(using: .utf8)
         }
         else {
             return nil
         }
     }
     
-    if let string = body as? String where contentType.hasPrefix("text/") {
-        return string.dataUsingEncoding(NSUTF8StringEncoding)
+    if let string = body as? String, contentType.hasPrefix("text/") {
+        return string.data(using: .utf8)
     }
     
     if contentType.hasPrefix("application/json") {
-        return try? NSJSONSerialization.dataWithJSONObject(body, options: [])
+        return try? JSONSerialization.data(withJSONObject: body, options: [])
     }
     
     if let string = body as? String {
-        return NSData(base64EncodedString: string, options: [])
+        return Data(base64Encoded: string, options: [])
     }
     
     return nil

--- a/Vinyl/ErrorHandler/ErrorHandler.swift
+++ b/Vinyl/ErrorHandler/ErrorHandler.swift
@@ -9,13 +9,13 @@
 import Foundation
 
 protocol ErrorHandler {
-    func handleTrackNotFound(request: Request, playTracksUniquely: Bool)
+    func handleTrackNotFound(_ request: Request, playTracksUniquely: Bool)
     func handleUnknownError()
 }
 
 struct DefaultErrorHandler: ErrorHandler {
     
-    func handleTrackNotFound(request: Request, playTracksUniquely: Bool) {
+    func handleTrackNotFound(_ request: Request, playTracksUniquely: Bool) {
      
         if playTracksUniquely {
             fatalError("💥 No 🎶 recorded and matchable with request: \n\(request.debugDescription)\n\nThis might be happening because you are trying to consume the same request multiple times 😩\n")

--- a/Vinyl/Extensions/Bundle.swift
+++ b/Vinyl/Extensions/Bundle.swift
@@ -1,5 +1,5 @@
 //
-//  NSBundle.swift
+//  Bundle.swift
 //  Vinyl
 //
 //  Created by Rui Peres on 19/02/2016.
@@ -9,9 +9,9 @@
 import Foundation
 
 // Idea taken from Venmo/DVR (thanks!)
-func testingBundle() -> NSBundle {
+func testingBundle() -> Bundle {
     
-    let bundleArray = NSBundle.allBundles().filter() { $0.bundlePath.hasSuffix(".xctest") }
+    let bundleArray = Bundle.allBundles.filter() { $0.bundlePath.hasSuffix(".xctest") }
     
     guard bundleArray.count != 0 else {
         fatalError("We were not able to find a suitable bundle, please specify it manually 🙁\nE.g:`Turntable(vinylName: \"your_vinyl\", bundle: your_bundle)`.")

--- a/Vinyl/Extensions/SequenceType.swift
+++ b/Vinyl/Extensions/SequenceType.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-extension SequenceType {
+extension Sequence {
     
-    func any(@noescape f: Self.Generator.Element -> Bool) -> Bool {
+    func any(_ f: (Self.Iterator.Element) -> Bool) -> Bool {
         
         for element in self where f(element) {
             return true
@@ -19,7 +19,7 @@ extension SequenceType {
         return false
     }
     
-    func all(@noescape f: Self.Generator.Element -> Bool) -> Bool {
+    func all(_ f: (Self.Iterator.Element) -> Bool) -> Bool {
         
         for element in self where f(element) == false {
             return false
@@ -28,7 +28,7 @@ extension SequenceType {
         return true
     }
     
-    func first(@noescape f: Self.Generator.Element -> Bool) -> Self.Generator.Element? {
+    func first(_ f: (Self.Iterator.Element) -> Bool) -> Self.Iterator.Element? {
         
         for element in self where f(element) {
             return element

--- a/Vinyl/Extensions/SequenceType.swift
+++ b/Vinyl/Extensions/SequenceType.swift
@@ -27,13 +27,4 @@ extension Sequence {
         
         return true
     }
-    
-    func first(_ f: (Self.Iterator.Element) -> Bool) -> Self.Iterator.Element? {
-        
-        for element in self where f(element) {
-            return element
-        }
-        
-        return nil
-    }
 }

--- a/Vinyl/Extensions/URLQueryItem.swift
+++ b/Vinyl/Extensions/URLQueryItem.swift
@@ -8,9 +8,9 @@
 
 import Foundation
 
-extension URLQueryItem: Comparable { }
-
-public func < (lhs: URLQueryItem, rhs: URLQueryItem) -> Bool {
+extension URLQueryItem: Comparable {
     
-    return lhs.name < rhs.name
+    public static func < (lhs: URLQueryItem, rhs: URLQueryItem) -> Bool {
+        return lhs.name < rhs.name
+    }
 }

--- a/Vinyl/Extensions/URLQueryItem.swift
+++ b/Vinyl/Extensions/URLQueryItem.swift
@@ -1,5 +1,5 @@
 //
-//  NSURLQueryItem.swift
+//  URLQueryItem.swift
 //  Vinyl
 //
 //  Created by Rui Peres on 16/02/2016.
@@ -8,9 +8,9 @@
 
 import Foundation
 
-extension NSURLQueryItem: Comparable { }
+extension URLQueryItem: Comparable { }
 
-public func < (lhs: NSURLQueryItem, rhs: NSURLQueryItem) -> Bool {
+public func < (lhs: URLQueryItem, rhs: URLQueryItem) -> Bool {
     
     return lhs.name < rhs.name
 }

--- a/Vinyl/Extensions/URLRequest.swift
+++ b/Vinyl/Extensions/URLRequest.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension URLRequest {
     
-    static func createWithEncodedRequest(_ encodedRequest: EncodedObject) -> URLRequest {
+    static func create(with encodedRequest: EncodedObject) -> URLRequest {
         guard
             let urlString = encodedRequest["url"] as? String,
             let url = URL(string: urlString)
@@ -27,7 +27,7 @@ extension URLRequest {
         if let headers = encodedRequest["headers"] as? HTTPHeaders {
             request.allHTTPHeaderFields = headers
             
-            if let body = decodeBody(encodedRequest["body"], headers: headers) {
+            if let body = decode(body: encodedRequest["body"], headers: headers) {
                 request.httpBody = body
             }
         }
@@ -38,12 +38,12 @@ extension URLRequest {
     func encodedObject() -> EncodedObject {
         var json = EncodedObject()
         
-        json["url"] = url?.absoluteString as AnyObject?
-        json["method"] = httpMethod as AnyObject?
+        json["url"] = url?.absoluteString
+        json["method"] = httpMethod
         
         if let headers = allHTTPHeaderFields {
-            json["headers"] = headers as AnyObject?
-            json["body"] = encodeBody(httpBody, headers: headers) as AnyObject?
+            json["headers"] = headers
+            json["body"] = encode(body: httpBody, headers: headers)
         }
         
         return json

--- a/Vinyl/Extensions/URLRequest.swift
+++ b/Vinyl/Extensions/URLRequest.swift
@@ -1,5 +1,5 @@
 //
-//  NSURLRequest.swift
+//  URLRequest.swift
 //  Vinyl
 //
 //  Created by Rui Peres on 16/02/2016.
@@ -8,42 +8,42 @@
 
 import Foundation
 
-extension NSURLRequest {
+extension URLRequest {
     
-    class func createWithEncodedRequest(encodedRequest: EncodedObject) -> NSURLRequest {
+    static func createWithEncodedRequest(_ encodedRequest: EncodedObject) -> URLRequest {
         guard
             let urlString = encodedRequest["url"] as? String,
-            let url = NSURL(string: urlString)
+            let url = URL(string: urlString)
             else {
                 fatalError("URL not found 😞 for Request: \(encodedRequest)")
         }
         
-        let request = NSMutableURLRequest(URL: url)
+        let request = NSMutableURLRequest(url: url)
         
         if let method = encodedRequest["method"] as? String {
-            request.HTTPMethod = method
+            request.httpMethod = method
         }
         
         if let headers = encodedRequest["headers"] as? HTTPHeaders {
             request.allHTTPHeaderFields = headers
             
             if let body = decodeBody(encodedRequest["body"], headers: headers) {
-                request.HTTPBody = body
+                request.httpBody = body
             }
         }
         
-        return request
+        return request as URLRequest
     }
     
     func encodedObject() -> EncodedObject {
         var json = EncodedObject()
         
-        json["url"] = URL?.absoluteString
-        json["method"] = HTTPMethod
+        json["url"] = url?.absoluteString as AnyObject?
+        json["method"] = httpMethod as AnyObject?
         
         if let headers = allHTTPHeaderFields {
-            json["headers"] = headers
-            json["body"] = encodeBody(HTTPBody, headers: headers)
+            json["headers"] = headers as AnyObject?
+            json["body"] = encodeBody(httpBody, headers: headers) as AnyObject?
         }
         
         return json

--- a/Vinyl/JSON_Helpers/JSONHelper.swift
+++ b/Vinyl/JSON_Helpers/JSONHelper.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-func loadJSON<T>(_ bundle: Bundle, fileName: String) -> T?  {
+func loadJSON<T>(from bundle: Bundle, fileName: String) -> T?  {
     
     guard
         let path = bundle.path(forResource: fileName, ofType: "json"),
         let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
-        let jsonData = try? JSONSerialization.jsonObject(with: data, options: []) as? T
+        let jsonData = try? JSONSerialization.jsonObject(with: data) as? T
     else {
         return nil
     }

--- a/Vinyl/JSON_Helpers/JSONHelper.swift
+++ b/Vinyl/JSON_Helpers/JSONHelper.swift
@@ -8,12 +8,12 @@
 
 import Foundation
 
-func loadJSON<T>(bundle: NSBundle, fileName: String) -> T?  {
+func loadJSON<T>(_ bundle: Bundle, fileName: String) -> T?  {
     
     guard
-        let path = bundle.pathForResource(fileName, ofType: "json"),
-        data = NSData(contentsOfFile: path),
-        jsonData = try? NSJSONSerialization.JSONObjectWithData(data, options: []) as? T
+        let path = bundle.path(forResource: fileName, ofType: "json"),
+        let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+        let jsonData = try? JSONSerialization.jsonObject(with: data, options: []) as? T
     else {
         return nil
     }

--- a/Vinyl/Player.swift
+++ b/Vinyl/Player.swift
@@ -13,19 +13,19 @@ struct Player {
     let vinyl: Vinyl
     let trackMatchers: [TrackMatcher]
     
-    private func seekTrackForRequest(request: Request) -> Track? {
-        return vinyl.tracks.first { track in
+    fileprivate func seekTrackForRequest(_ request: Request) -> Track? {
+        return vinyl.tracks.first({ track in
             trackMatchers.all { matcher in matcher.matchableTrack(request, track: track) }
-        }
+        })
     }
     
-    func playTrack(forRequest request: Request) throws -> (data: NSData?, response: NSURLResponse?, error: NSError?) {
+    func playTrack(forRequest request: Request) throws -> (data: Data?, response: URLResponse?, error: Error?) {
         
         guard let track = self.seekTrackForRequest(request) else {
-            throw Error.TrackNotFound
+            throw TurntableError.trackNotFound
         }
         
-        return (data: track.response.body, response: track.response.urlResponse, error: track.response.error)
+        return (data: track.response.body as Data?, response: track.response.urlResponse, error: track.response.error)
     }
     
     func trackExists(forRequest request: Request) -> Bool {

--- a/Vinyl/Player.swift
+++ b/Vinyl/Player.swift
@@ -13,23 +13,23 @@ struct Player {
     let vinyl: Vinyl
     let trackMatchers: [TrackMatcher]
     
-    fileprivate func seekTrackForRequest(_ request: Request) -> Track? {
-        return vinyl.tracks.first({ track in
-            trackMatchers.all { matcher in matcher.matchableTrack(request, track: track) }
-        })
+    fileprivate func seekTrack(for request: Request) -> Track? {
+        return vinyl.tracks.first { track in
+            trackMatchers.all { matcher in matcher.matchable(track: track, for: request) }
+        }
     }
     
-    func playTrack(forRequest request: Request) throws -> (data: Data?, response: URLResponse?, error: Error?) {
+    func playTrack(for request: Request) throws -> (data: Data?, response: URLResponse?, error: Error?) {
         
-        guard let track = self.seekTrackForRequest(request) else {
+        guard let track = self.seekTrack(for: request) else {
             throw TurntableError.trackNotFound
         }
         
         return (data: track.response.body as Data?, response: track.response.urlResponse, error: track.response.error)
     }
     
-    func trackExists(forRequest request: Request) -> Bool {
-        if let _ = self.seekTrackForRequest(request) {
+    func trackExists(for request: Request) -> Bool {
+        if let _ = self.seekTrack(for: request) {
             return true
         }
         

--- a/Vinyl/Recorder.swift
+++ b/Vinyl/Recorder.swift
@@ -20,14 +20,14 @@ final class Recorder {
 }
 
 extension Recorder {
-    func saveTrack(withRequest request: Request, response: Response) {
-        wax.addTrack(Track(request: request, response: response))
+    func saveTrack(with request: Request, response: Response) {
+        wax.add(track: Track(request: request, response: response))
         somethingRecorded = true
     }
     
-    func saveTrack(withRequest request: Request, urlResponse: HTTPURLResponse?, body: Data? = nil, error: Error? = nil) {
+    func saveTrack(with request: Request, urlResponse: HTTPURLResponse?, body: Data? = nil, error: Error? = nil) {
         let response = Response(urlResponse: urlResponse, body: body, error: error)
-        saveTrack(withRequest: request, response: response)
+        saveTrack(with: request, response: response)
     }
 }
 

--- a/Vinyl/Recorder.swift
+++ b/Vinyl/Recorder.swift
@@ -25,7 +25,7 @@ extension Recorder {
         somethingRecorded = true
     }
     
-    func saveTrack(withRequest request: Request, urlResponse: NSHTTPURLResponse?, body: NSData? = nil, error: NSError? = nil) {
+    func saveTrack(withRequest request: Request, urlResponse: HTTPURLResponse?, body: Data? = nil, error: Error? = nil) {
         let response = Response(urlResponse: urlResponse, body: body, error: error)
         saveTrack(withRequest: request, response: response)
     }
@@ -34,17 +34,17 @@ extension Recorder {
 extension Recorder {
     
     func persist() throws {
-        guard let recordingPath = recordingPath where somethingRecorded else {
+        guard let recordingPath = recordingPath, somethingRecorded else {
             if somethingRecorded {
-                throw Error.NoRecordingPath
+                throw TurntableError.noRecordingPath
             } else {
-                throw Error.NothingToRecord
+                throw TurntableError.nothingToRecord
             }
         }
         
-        let fileManager = NSFileManager.defaultManager()
-        guard fileManager.createFileAtPath(recordingPath, contents: nil, attributes: nil) == true,
-            let file = NSFileHandle(forWritingAtPath: recordingPath) else {
+        let fileManager = FileManager.default
+        guard fileManager.createFile(atPath: recordingPath, contents: nil, attributes: nil) == true,
+            let file = FileHandle(forWritingAtPath: recordingPath) else {
             return
         }
         
@@ -52,8 +52,8 @@ extension Recorder {
             $0.encodedTrack()
         }
         
-        let data = try NSJSONSerialization.dataWithJSONObject(jsonWax, options: .PrettyPrinted)
-        file.writeData(data)
+        let data = try JSONSerialization.data(withJSONObject: jsonWax, options: .prettyPrinted)
+        file.write(data)
         file.synchronizeFile()
         
         print("Vinyl recorded to: \(recordingPath)")

--- a/Vinyl/RequestMatcherRegistry.swift
+++ b/Vinyl/RequestMatcherRegistry.swift
@@ -9,49 +9,49 @@
 import Foundation
 
 public enum RequestMatcherType {
-    case Method
-    case URL
-    case Path
-    case Query
-    case Headers
-    case Body
-    case Custom(RequestMatcher)
+    case method
+    case url
+    case path
+    case query
+    case headers
+    case body
+    case custom(RequestMatcher)
 }
 
 public protocol RequestMatcher {
-    func match(aRequest: Request, anotherRequest: Request) -> Bool
+    func match(_ aRequest: Request, anotherRequest: Request) -> Bool
 }
 
 public struct RequestMatcherRegistry {
     
-    private let registeredTypes: [RequestMatcherType]
-    private let matchingChain: [RequestMatcher]
+    fileprivate let registeredTypes: [RequestMatcherType]
+    fileprivate let matchingChain: [RequestMatcher]
     
     init(types: [RequestMatcherType]) {
         registeredTypes = types
         matchingChain = types.map { RequestMatcherRegistry.matcherForType($0) }
     }
     
-    func matchableRequests(aRequest: Request, anotherRequest: Request) -> Bool {
+    func matchableRequests(_ aRequest: Request, anotherRequest: Request) -> Bool {
         
         return matchingChain.all { $0.match(aRequest, anotherRequest: anotherRequest) }
     }
     
-    private static func matcherForType(requestMatcherType: RequestMatcherType) -> RequestMatcher {
+    fileprivate static func matcherForType(_ requestMatcherType: RequestMatcherType) -> RequestMatcher {
         switch requestMatcherType {
-        case .Method:
+        case .method:
             return MethodRequestMatcher()
-        case .URL:
+        case .url:
             return URLRequestMatcher()
-        case .Path:
+        case .path:
             return PathRequestMatcher()
-        case .Query:
+        case .query:
             return QueryRequestMatcher()
-        case .Headers:
+        case .headers:
             return HeadersRequestMatcher()
-        case .Body:
+        case .body:
             return BodyRequestMatcher()
-        case .Custom(let customRequestMatcher):
+        case .custom(let customRequestMatcher):
             return customRequestMatcher
         }
     }
@@ -60,51 +60,51 @@ public struct RequestMatcherRegistry {
 // MARK: - Matchers
 
 private struct MethodRequestMatcher: RequestMatcher {
-    func match(aRequest: Request, anotherRequest: Request) -> Bool {
+    func match(_ aRequest: Request, anotherRequest: Request) -> Bool {
         // `caseInsensitiveCompare` doesn't support an optional, to prevent unwrapping and perform more than one comparison we can capitalize both methods and rely on optionals to do the hard-work
-        return aRequest.HTTPMethod?.capitalizedString == anotherRequest.HTTPMethod?.capitalizedString
+        return aRequest.httpMethod?.capitalized == anotherRequest.httpMethod?.capitalized
     }
 }
 
 private  struct URLRequestMatcher: RequestMatcher {
-    func match(aRequest: Request, anotherRequest: Request) -> Bool {
-        return aRequest.URL == anotherRequest.URL
+    func match(_ aRequest: Request, anotherRequest: Request) -> Bool {
+        return aRequest.url == anotherRequest.url
     }
 }
 
 private  struct PathRequestMatcher: RequestMatcher {
-    func match(aRequest: Request, anotherRequest: Request) -> Bool {
-        return aRequest.URL?.path == anotherRequest.URL?.path
+    func match(_ aRequest: Request, anotherRequest: Request) -> Bool {
+        return aRequest.url?.path == anotherRequest.url?.path
     }
 }
 
 private struct QueryRequestMatcher: RequestMatcher {
-    func match(aRequest: Request, anotherRequest: Request) -> Bool {
+    func match(_ aRequest: Request, anotherRequest: Request) -> Bool {
         
-        let queryItems: Request -> [NSURLQueryItem] = { request in
-            let components = NSURLComponents(string: request.URL?.absoluteString ?? "")
+        let queryItems: (Request) -> [URLQueryItem] = { request in
+            let components = URLComponents(string: request.url?.absoluteString ?? "")
             return components?.queryItems ?? []
         }
         
-        let aRequestItems = queryItems(aRequest).sort(>)
-        let anotherRequestItems = queryItems(anotherRequest).sort(>)
+        let aRequestItems = queryItems(aRequest).sorted(by: >)
+        let anotherRequestItems = queryItems(anotherRequest).sorted(by: >)
     
         return aRequestItems == anotherRequestItems
     }
 }
 
 private struct HeadersRequestMatcher: RequestMatcher {
-    func match(aRequest: Request, anotherRequest: Request) -> Bool {
+    func match(_ aRequest: Request, anotherRequest: Request) -> Bool {
         
-        let headers: Request -> HTTPHeaders  = { request in
+        let headers: (Request) -> HTTPHeaders  = { request in
             return request.allHTTPHeaderFields ?? [:]
         }
         
-        let toLowerCase: HTTPHeaders -> HTTPHeaders = { dic in
+        let toLowerCase: (HTTPHeaders) -> HTTPHeaders = { dic in
         
             var loweredCase: HTTPHeaders = [:]
             for key in dic.keys {
-                loweredCase[key.lowercaseString] = dic[key]?.lowercaseString
+                loweredCase[key.lowercased()] = dic[key]?.lowercased()
             }
             return loweredCase
         }
@@ -119,15 +119,15 @@ private struct HeadersRequestMatcher: RequestMatcher {
 }
 
 private struct BodyRequestMatcher: RequestMatcher {
-    func match(aRequest: Request, anotherRequest: Request) -> Bool {
+    func match(_ aRequest: Request, anotherRequest: Request) -> Bool {
 
-        switch (aRequest.HTTPBody, anotherRequest.HTTPBody) {
-        case (.None, .None): return true
-        case (.Some(let lhsData), .Some(let rhsData)):
+        switch (aRequest.httpBody, anotherRequest.httpBody) {
+        case (.none, .none): return true
+        case (.some(let lhsData), .some(let rhsData)):
             guard let lhsHeaders = aRequest.allHTTPHeaderFields,
-                rhsHeaders = anotherRequest.allHTTPHeaderFields,
-            lhsBody = encodeBody(lhsData, headers: lhsHeaders),
-            rhsBody = encodeBody(rhsData, headers: rhsHeaders) else { return lhsData == rhsData }
+                let rhsHeaders = anotherRequest.allHTTPHeaderFields,
+            let lhsBody = encodeBody(lhsData, headers: lhsHeaders),
+            let rhsBody = encodeBody(rhsData, headers: rhsHeaders) else { return lhsData == rhsData }
             return lhsBody.isEqual(rhsBody)
         default: return false
         }

--- a/Vinyl/Response.swift
+++ b/Vinyl/Response.swift
@@ -33,17 +33,17 @@ extension Response {
             fatalError("key not found 😞 for Response (check url/statusCode/headers) check \n------\n\(encodedResponse)\n------\n")
         }
         
-        self.init(urlResponse: urlResponse, body: decodeBody(encodedResponse["body"], headers: headers), error: nil)
+        self.init(urlResponse: urlResponse, body: decode(body: encodedResponse["body"], headers: headers), error: nil)
     }
     
     func encodedObject() -> EncodedObject {
         var json = EncodedObject()
         
         if let response = urlResponse {
-            json["url"] = response.url?.absoluteString as AnyObject?
-            json["status"] = response.statusCode as AnyObject?
-            json["headers"] = response.allHeaderFields as AnyObject?
-            json["body"] = encodeBody(body, headers: response.allHeaderFields as! [String : String]) as AnyObject?
+            json["url"] = response.url?.absoluteString
+            json["status"] = response.statusCode
+            json["headers"] = response.allHeaderFields
+            json["body"] = encode(body: body, headers: response.allHeaderFields as! [String : String])
         }
         
         return json
@@ -58,8 +58,7 @@ func ==(lhs: Response, rhs: Response) -> Bool {
 
 extension Response: Hashable {
     
-    var hashValue: Int {
-        
+    var hashValue: Int {        
         let body = self.body == nil ? "\(self.body)" : ""
         let error = self.error == nil ? "\(self.error)" : ""
         

--- a/Vinyl/Response.swift
+++ b/Vinyl/Response.swift
@@ -51,7 +51,9 @@ extension Response {
 }
 
 func ==(lhs: Response, rhs: Response) -> Bool {
-    return lhs.urlResponse == rhs.urlResponse && lhs.body == rhs.body // && lhs.error == rhs.error
+    return lhs.urlResponse == rhs.urlResponse
+        && lhs.body == rhs.body
+        && lhs.error?.localizedDescription == rhs.error?.localizedDescription
 }
 
 extension Response: Hashable {

--- a/Vinyl/Response.swift
+++ b/Vinyl/Response.swift
@@ -53,7 +53,8 @@ extension Response {
 func ==(lhs: Response, rhs: Response) -> Bool {
     return lhs.urlResponse == rhs.urlResponse
         && lhs.body == rhs.body
-        && lhs.error?.localizedDescription == rhs.error?.localizedDescription
+        && lhs.error?._domain == rhs.error?._domain
+        && lhs.error?._code   == rhs.error?._code
 }
 
 extension Response: Hashable {

--- a/Vinyl/Response.swift
+++ b/Vinyl/Response.swift
@@ -9,11 +9,11 @@
 import Foundation
 
 struct Response {
-    let urlResponse: NSHTTPURLResponse?
-    let body: NSData?
-    let error: NSError?
+    let urlResponse: HTTPURLResponse?
+    let body: Data?
+    let error: Error?
     
-    init(urlResponse: NSHTTPURLResponse?, body: NSData? = nil, error: NSError? = nil) {
+    init(urlResponse: HTTPURLResponse?, body: Data? = nil, error: Error? = nil) {
         self.urlResponse = urlResponse
         self.body = body
         self.error = error
@@ -25,10 +25,10 @@ extension Response {
     init(encodedResponse: EncodedObject) {
         guard
             let urlString = encodedResponse["url"] as? String,
-            let url =  NSURL(string: urlString),
+            let url =  URL(string: urlString),
             let statusCode = encodedResponse["status"] as? Int,
             let headers = encodedResponse["headers"] as? HTTPHeaders,
-            let urlResponse = NSHTTPURLResponse(URL: url, statusCode: statusCode, HTTPVersion: nil, headerFields: headers)
+            let urlResponse = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: headers)
         else {
             fatalError("key not found 😞 for Response (check url/statusCode/headers) check \n------\n\(encodedResponse)\n------\n")
         }
@@ -40,10 +40,10 @@ extension Response {
         var json = EncodedObject()
         
         if let response = urlResponse {
-            json["url"] = response.URL?.absoluteString
-            json["status"] = response.statusCode
-            json["headers"] = response.allHeaderFields
-            json["body"] = encodeBody(body, headers: response.allHeaderFields as! [String : String])
+            json["url"] = response.url?.absoluteString as AnyObject?
+            json["status"] = response.statusCode as AnyObject?
+            json["headers"] = response.allHeaderFields as AnyObject?
+            json["body"] = encodeBody(body, headers: response.allHeaderFields as! [String : String]) as AnyObject?
         }
         
         return json
@@ -51,15 +51,15 @@ extension Response {
 }
 
 func ==(lhs: Response, rhs: Response) -> Bool {
-    return lhs.urlResponse == rhs.urlResponse && lhs.body == rhs.body && lhs.error == rhs.error
+    return lhs.urlResponse == rhs.urlResponse && lhs.body == rhs.body // && lhs.error == rhs.error
 }
 
 extension Response: Hashable {
     
     var hashValue: Int {
         
-        let body = self.body ?? ""
-        let error = self.error ?? ""
+        let body = self.body == nil ? "\(self.body)" : ""
+        let error = self.error == nil ? "\(self.error)" : ""
         
         return "\(urlResponse?.hashValue):\((body)):\(error)".hashValue
     }    

--- a/Vinyl/Track.swift
+++ b/Vinyl/Track.swift
@@ -11,7 +11,7 @@ import Foundation
 public typealias EncodedObject = [String : AnyObject]
 public typealias HTTPHeaders = [String : String]
 
-public typealias Request = NSURLRequest
+public typealias Request = URLRequest
 
 public struct Track {
     let request: Request
@@ -26,10 +26,10 @@ public struct Track {
         
         self.response = response
         
-        let urlString = response.urlResponse?.URL?.absoluteString
-        let url = NSURL(string: urlString!)!
+        let urlString = response.urlResponse?.url?.absoluteString
+        let url = URL(string: urlString!)!
         
-        self.request = NSURLRequest(URL: url)
+        self.request = URLRequest(url: url)
     }
 }
 
@@ -60,8 +60,8 @@ extension Track {
     func encodedTrack() -> EncodedObject {
         var json = EncodedObject()
         
-        json["request"] = request.encodedObject()
-        json["response"] = response.encodedObject()
+        json["request"] = request.encodedObject() as AnyObject?
+        json["response"] = response.encodedObject() as AnyObject?
         
         return json
     }
@@ -83,10 +83,10 @@ public func ==(lhs: Track, rhs: Track) -> Bool {
 
 public struct TrackFactory {
     
-    public static func createTrack(url: NSURL, statusCode: Int, body: NSData? = nil, error: NSError? = nil, headers: HTTPHeaders = [:]) -> Track {
+    public static func createTrack(_ url: URL, statusCode: Int, body: Data? = nil, error: Error? = nil, headers: HTTPHeaders = [:]) -> Track {
         
         guard
-            let response = NSHTTPURLResponse(URL: url, statusCode: statusCode, HTTPVersion: nil, headerFields: headers)
+            let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: headers)
             else {
                 fatalError("We weren't able to create the Track 😫")
         }
@@ -95,27 +95,27 @@ public struct TrackFactory {
         return track
     }
     
-    public static func createBadTrack(url: NSURL, statusCode: Int, error: NSError? = nil, headers: HTTPHeaders = [:]) -> Track {
+    public static func createBadTrack(_ url: URL, statusCode: Int, error: Error? = nil, headers: HTTPHeaders = [:]) -> Track {
         
         return createTrack(url, statusCode: statusCode, body: nil, error: error, headers: headers)
     }
 
-    public static func createErrorTrack(url: NSURL, error: NSError) -> Track {
+    public static func createErrorTrack(_ url: URL, error: Error) -> Track {
 
-        let request = NSURLRequest(URL: url)
+        let request = URLRequest(url: url)
         let response = Response(urlResponse: nil, body: nil, error: error)
         return Track(request: request, response: response)
     }
     
-    public static func createValidTrack(url: NSURL, body: NSData? = nil, headers: HTTPHeaders = [:]) -> Track {
+    public static func createValidTrack(_ url: URL, body: Data? = nil, headers: HTTPHeaders = [:]) -> Track {
         
         return createTrack(url, statusCode: 200, body: body, error: nil, headers: headers)
     }
     
-    public static func createValidTrackFromJSON(url: NSURL, json: AnyObject, headers: HTTPHeaders = [:]) -> Track {
+    public static func createValidTrackFromJSON(_ url: URL, json: AnyObject, headers: HTTPHeaders = [:]) -> Track {
         
         do {
-            let body = try NSJSONSerialization.dataWithJSONObject(json, options: .PrettyPrinted)
+            let body = try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
             return createTrack(url, statusCode: 200, body: body, error: nil, headers: headers)
         }
         catch {
@@ -123,15 +123,15 @@ public struct TrackFactory {
         }
     }
     
-    public static func createValidTrackFromBase64(url: NSURL, bodyString: String, headers: HTTPHeaders = [:]) -> Track {
+    public static func createValidTrackFromBase64(_ url: URL, bodyString: String, headers: HTTPHeaders = [:]) -> Track {
         
-        let body = NSData(base64EncodedString: bodyString, options: .IgnoreUnknownCharacters)
+        let body = Data(base64Encoded: bodyString, options: .ignoreUnknownCharacters)
         return createTrack(url, statusCode: 200, body: body, error: nil, headers: headers)
     }
     
-    public static func createValidTrackFromUTF8(url: NSURL, bodyString: String, headers: HTTPHeaders = [:]) -> Track {
+    public static func createValidTrackFromUTF8(_ url: URL, bodyString: String, headers: HTTPHeaders = [:]) -> Track {
         
-        let body = bodyString.dataUsingEncoding(NSUTF8StringEncoding)
+        let body = bodyString.data(using: String.Encoding.utf8)
         return createTrack(url, statusCode: 200, body: body, error: nil, headers: headers)
     }
 }

--- a/Vinyl/Track.swift
+++ b/Vinyl/Track.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public typealias EncodedObject = [String : AnyObject]
+public typealias EncodedObject = [String : Any]
 public typealias HTTPHeaders = [String : String]
 
 public typealias Request = URLRequest
@@ -23,7 +23,6 @@ public struct Track {
     }
     
     init(response: Response) {
-        
         self.response = response
         
         let urlString = response.urlResponse?.url?.absoluteString
@@ -38,7 +37,6 @@ public struct Track {
 extension Track {
     
     init(encodedTrack: EncodedObject) {
-        
         guard let encodedResponse = encodedTrack["response"] as? EncodedObject else {
             fatalError("request/response not found 😞 for Track: \(encodedTrack)")
         }
@@ -48,7 +46,7 @@ extension Track {
         if let encodedRequest = encodedTrack["request"] as? EncodedObject {
             
             // We're using a helper function because we cannot mutate a NSURLRequest directly
-            let request = Request.createWithEncodedRequest(encodedRequest)
+            let request = Request.create(with: encodedRequest)
             
             self.init(request: request, response: response)
             
@@ -60,8 +58,8 @@ extension Track {
     func encodedTrack() -> EncodedObject {
         var json = EncodedObject()
         
-        json["request"] = request.encodedObject() as AnyObject?
-        json["response"] = response.encodedObject() as AnyObject?
+        json["request"] = request.encodedObject()
+        json["response"] = response.encodedObject()
         
         return json
     }
@@ -83,7 +81,7 @@ public func ==(lhs: Track, rhs: Track) -> Bool {
 
 public struct TrackFactory {
     
-    public static func createTrack(_ url: URL, statusCode: Int, body: Data? = nil, error: Error? = nil, headers: HTTPHeaders = [:]) -> Track {
+    public static func createTrack(url: URL, statusCode: Int, body: Data? = nil, error: Error? = nil, headers: HTTPHeaders = [:]) -> Track {
         
         guard
             let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: headers)
@@ -95,43 +93,43 @@ public struct TrackFactory {
         return track
     }
     
-    public static func createBadTrack(_ url: URL, statusCode: Int, error: Error? = nil, headers: HTTPHeaders = [:]) -> Track {
+    public static func createBadTrack(url: URL, statusCode: Int, error: Error? = nil, headers: HTTPHeaders = [:]) -> Track {
         
-        return createTrack(url, statusCode: statusCode, body: nil, error: error, headers: headers)
+        return createTrack(url: url, statusCode: statusCode, body: nil, error: error, headers: headers)
     }
 
-    public static func createErrorTrack(_ url: URL, error: Error) -> Track {
+    public static func createErrorTrack(url: URL, error: Error) -> Track {
 
         let request = URLRequest(url: url)
         let response = Response(urlResponse: nil, body: nil, error: error)
         return Track(request: request, response: response)
     }
     
-    public static func createValidTrack(_ url: URL, body: Data? = nil, headers: HTTPHeaders = [:]) -> Track {
+    public static func createValidTrack(url: URL, body: Data? = nil, headers: HTTPHeaders = [:]) -> Track {
         
-        return createTrack(url, statusCode: 200, body: body, error: nil, headers: headers)
+        return createTrack(url: url, statusCode: 200, body: body, error: nil, headers: headers)
     }
     
-    public static func createValidTrackFromJSON(_ url: URL, json: AnyObject, headers: HTTPHeaders = [:]) -> Track {
+    public static func createValidTrack(url: URL, jsonBody: AnyObject, headers: HTTPHeaders = [:]) -> Track {
         
         do {
-            let body = try JSONSerialization.data(withJSONObject: json, options: .prettyPrinted)
-            return createTrack(url, statusCode: 200, body: body, error: nil, headers: headers)
+            let body = try JSONSerialization.data(withJSONObject: jsonBody, options: .prettyPrinted)
+            return createTrack(url: url, statusCode: 200, body: body, error: nil, headers: headers)
         }
         catch {
             fatalError("Invalid JSON 😕\nBefore trying again check your JSON here http://jsonlint.com/ 👍")
         }
     }
     
-    public static func createValidTrackFromBase64(_ url: URL, bodyString: String, headers: HTTPHeaders = [:]) -> Track {
+    public static func createValidTrack(url: URL, base64Body: String, headers: HTTPHeaders = [:]) -> Track {
         
-        let body = Data(base64Encoded: bodyString, options: .ignoreUnknownCharacters)
-        return createTrack(url, statusCode: 200, body: body, error: nil, headers: headers)
+        let body = Data(base64Encoded: base64Body, options: .ignoreUnknownCharacters)
+        return createTrack(url: url, statusCode: 200, body: body, error: nil, headers: headers)
     }
     
-    public static func createValidTrackFromUTF8(_ url: URL, bodyString: String, headers: HTTPHeaders = [:]) -> Track {
+    public static func createValidTrack(url: URL, utf8Body: String, headers: HTTPHeaders = [:]) -> Track {
         
-        let body = bodyString.data(using: String.Encoding.utf8)
-        return createTrack(url, statusCode: 200, body: body, error: nil, headers: headers)
+        let body = utf8Body.data(using: String.Encoding.utf8)
+        return createTrack(url: url, statusCode: 200, body: body, error: nil, headers: headers)
     }
 }

--- a/Vinyl/TrackMatcher.swift
+++ b/Vinyl/TrackMatcher.swift
@@ -9,13 +9,13 @@
 import Foundation
 
 protocol TrackMatcher {
-    func matchableTrack(request: Request, track: Track) -> Bool
+    func matchableTrack(_ request: Request, track: Track) -> Bool
 }
 
 // We cannot use a struct, otherwise we need to mark `-matchableTrack` as mutating and that breaks protocol conformance (rdar://21966810)
 final class UniqueTrackMatcher: TrackMatcher {
 
-    private var availableTracks: [Track]
+    fileprivate var availableTracks: [Track]
     
     init(availableTracks: [Track]) {
         self.availableTracks = availableTracks
@@ -23,8 +23,8 @@ final class UniqueTrackMatcher: TrackMatcher {
     
     func matchableTrack(_: Request, track: Track) -> Bool {
         
-        if let index = availableTracks.indexOf(track) {
-            availableTracks.removeAtIndex(index)
+        if let index = availableTracks.index(of: track) {
+            availableTracks.remove(at: index)
             return true
         }
         
@@ -40,7 +40,7 @@ struct TypeTrackMatcher: TrackMatcher {
         self.requestMatcherRegistry = RequestMatcherRegistry(types: requestMatcherTypes)
     }
     
-    func matchableTrack(request: Request, track: Track) -> Bool {
+    func matchableTrack(_ request: Request, track: Track) -> Bool {
         return requestMatcherRegistry.matchableRequests(request, anotherRequest: track.request)
     }
 }

--- a/Vinyl/TrackMatcher.swift
+++ b/Vinyl/TrackMatcher.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 protocol TrackMatcher {
-    func matchableTrack(_ request: Request, track: Track) -> Bool
+    func matchable(track: Track, for request: Request) -> Bool
 }
 
 // We cannot use a struct, otherwise we need to mark `-matchableTrack` as mutating and that breaks protocol conformance (rdar://21966810)
@@ -21,7 +21,7 @@ final class UniqueTrackMatcher: TrackMatcher {
         self.availableTracks = availableTracks
     }
     
-    func matchableTrack(_: Request, track: Track) -> Bool {
+    func matchable(track: Track, for request: Request) -> Bool {
         
         if let index = availableTracks.index(of: track) {
             availableTracks.remove(at: index)
@@ -40,7 +40,7 @@ struct TypeTrackMatcher: TrackMatcher {
         self.requestMatcherRegistry = RequestMatcherRegistry(types: requestMatcherTypes)
     }
     
-    func matchableTrack(_ request: Request, track: Track) -> Bool {
-        return requestMatcherRegistry.matchableRequests(request, anotherRequest: track.request)
+    func matchable(track: Track, for request: Request) -> Bool {
+        return requestMatcherRegistry.matchableRequests(request: request, with: track.request)
     }
 }

--- a/Vinyl/Turntable.swift
+++ b/Vinyl/Turntable.swift
@@ -8,60 +8,60 @@
 
 import Foundation
 
-enum Error: ErrorType {
+enum TurntableError: Error {
     
-    case TrackNotFound
-    case NoRecordingPath
-    case NothingToRecord
+    case trackNotFound
+    case noRecordingPath
+    case nothingToRecord
 }
 
 public typealias Plastic = [[String: AnyObject]]
-typealias RequestCompletionHandler =  (NSData?, NSURLResponse?, NSError?) -> Void
+typealias RequestCompletionHandler =  (Data?, URLResponse?, Error?) -> Void
 
-public final class Turntable: NSURLSession {
+public final class Turntable: URLSession {
     
     var errorHandler: ErrorHandler = DefaultErrorHandler()
-    private let turntableConfiguration: TurntableConfiguration
-    private var player: Player?
-    private var recorder: Recorder?
-    private var recordingSession: NSURLSession?
-    private let operationQueue: NSOperationQueue
+    fileprivate let turntableConfiguration: TurntableConfiguration
+    fileprivate var player: Player?
+    fileprivate var recorder: Recorder?
+    fileprivate var recordingSession: URLSession?
+    fileprivate let operationQueue: OperationQueue
     
-    public init(configuration: TurntableConfiguration, delegateQueue: NSOperationQueue? = nil, urlSession: NSURLSession? = nil) {
+    public init(configuration: TurntableConfiguration, delegateQueue: OperationQueue? = nil, urlSession: URLSession? = nil) {
         
         turntableConfiguration = configuration
         if let delegateQueue = delegateQueue {
             operationQueue = delegateQueue
         } else {
-            operationQueue = NSOperationQueue()
+            operationQueue = OperationQueue()
             operationQueue.maxConcurrentOperationCount = 1
         }
         
         if configuration.recodingEnabled {
             recorder = Recorder(wax: Wax(tracks: []), recordingPath: configuration.recordingPath)
-            recordingSession = urlSession ?? NSURLSession.sharedSession()
+            recordingSession = urlSession ?? URLSession.shared
         }
         
         super.init()
     }
     
-    public convenience init(vinyl: Vinyl, turntableConfiguration: TurntableConfiguration = TurntableConfiguration(), delegateQueue: NSOperationQueue? = nil, urlSession: NSURLSession? = nil) {
+    public convenience init(vinyl: Vinyl, turntableConfiguration: TurntableConfiguration = TurntableConfiguration(), delegateQueue: OperationQueue? = nil, urlSession: URLSession? = nil) {
         self.init(configuration: turntableConfiguration, delegateQueue: delegateQueue, urlSession: urlSession)
         player = Turntable.createPlayer(vinyl, configuration: turntableConfiguration)
     }
     
-    public convenience init(cassetteName: String, bundle: NSBundle = testingBundle(), turntableConfiguration: TurntableConfiguration = TurntableConfiguration(), delegateQueue: NSOperationQueue? = nil, urlSession: NSURLSession? = nil) {
+    public convenience init(cassetteName: String, bundle: Bundle = testingBundle(), turntableConfiguration: TurntableConfiguration = TurntableConfiguration(), delegateQueue: OperationQueue? = nil, urlSession: URLSession? = nil) {
         let vinyl = Vinyl(plastic: Turntable.createCassettePlastic(cassetteName, bundle: bundle))
         self.init(vinyl: vinyl, turntableConfiguration: turntableConfiguration, delegateQueue: delegateQueue, urlSession: urlSession)
     }
     
-    public convenience init(vinylName: String, bundle: NSBundle = testingBundle(), turntableConfiguration: TurntableConfiguration = TurntableConfiguration(), delegateQueue: NSOperationQueue? = nil, urlSession: NSURLSession? = nil) {
+    public convenience init(vinylName: String, bundle: Bundle = testingBundle(), turntableConfiguration: TurntableConfiguration = TurntableConfiguration(), delegateQueue: OperationQueue? = nil, urlSession: URLSession? = nil) {
         let plastic = Turntable.createVinylPlastic(vinylName, bundle: bundle, recordingMode: turntableConfiguration.recordingMode)
         let vinyl = Vinyl(plastic: plastic ?? [])
         self.init(vinyl: vinyl, turntableConfiguration: turntableConfiguration, delegateQueue: delegateQueue, urlSession: urlSession)
         
         switch turntableConfiguration.recordingMode {
-        case .MissingVinyl where plastic == nil, .MissingTracks:
+        case .missingVinyl where plastic == nil, .missingTracks:
             recorder = Recorder(wax: Wax(vinyl: vinyl), recordingPath: recordingPath(fromConfiguration: turntableConfiguration, vinylName: vinylName, bundle: bundle))
         default:
             recorder = nil
@@ -81,10 +81,10 @@ public final class Turntable: NSURLSession {
         do {
             try recorder.persist()
         }
-        catch Error.NothingToRecord {
+        catch TurntableError.nothingToRecord {
             print("Nothing to record.")
         }
-        catch Error.NoRecordingPath {
+        catch TurntableError.noRecordingPath {
             fatalError("💣 no path was configured for saving the recording.")
         }
         catch let error as NSError {
@@ -94,7 +94,7 @@ public final class Turntable: NSURLSession {
     
     // MARK: - Private methods
 
-    private func playVinyl<URLSessionTask: URLSessionTaskType>(request request: NSURLRequest, fromData bodyData: NSData? = nil, completionHandler: RequestCompletionHandler) throws -> URLSessionTask {
+    fileprivate func playVinyl<URLSessionTask: URLSessionTaskType>(request: URLRequest, fromData bodyData: Data? = nil, completionHandler: @escaping RequestCompletionHandler) throws -> URLSessionTask {
         guard let player = player else {
             fatalError("Did you forget to load the Vinyl? 🎶")
         }
@@ -102,13 +102,13 @@ public final class Turntable: NSURLSession {
         let completion = try player.playTrack(forRequest: transformRequest(request, bodyData: bodyData))
 
         return URLSessionTask {
-            self.operationQueue.addOperationWithBlock {
+            self.operationQueue.addOperation {
                 completionHandler(completion.data, completion.response, completion.error)
             }
         }
     }
 
-    private func recordingHandler(request request: NSURLRequest, fromData bodyData: NSData? = nil, completionHandler: RequestCompletionHandler) -> RequestCompletionHandler {
+    fileprivate func recordingHandler(request: URLRequest, fromData bodyData: Data? = nil, completionHandler: @escaping RequestCompletionHandler) -> RequestCompletionHandler {
         guard let recorder = recorder else {
             fatalError("No recording started.")
         }
@@ -116,37 +116,37 @@ public final class Turntable: NSURLSession {
         return {
             data, response, error in
             
-            recorder.saveTrack(withRequest: self.transformRequest(request, bodyData: bodyData), urlResponse: response as? NSHTTPURLResponse, body: data, error: error)
+            recorder.saveTrack(withRequest: self.transformRequest(request, bodyData: bodyData), urlResponse: response as? HTTPURLResponse, body: data, error: error)
             
-            self.operationQueue.addOperationWithBlock {
+            self.operationQueue.addOperation {
                 completionHandler(data, response, error)
             }
         }
     }
     
-    private func transformRequest(request: NSURLRequest, bodyData: NSData? = nil) -> NSURLRequest {
+    fileprivate func transformRequest(_ request: URLRequest, bodyData: Data? = nil) -> URLRequest {
         guard let bodyData = bodyData else {
             return request
         }
 
-        guard let mutableRequest = request.mutableCopy() as? NSMutableURLRequest else {
+        guard let mutableRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
             fatalError("💥 Houston, we have a problem 🚀")
         }
 
-        mutableRequest.HTTPBody = bodyData
+        mutableRequest.httpBody = bodyData
 
-        return mutableRequest
+        return mutableRequest as URLRequest
     }
 
-    private func recordingPath(fromConfiguration configuration: TurntableConfiguration, vinylName: String, bundle: NSBundle) -> String? {
+    fileprivate func recordingPath(fromConfiguration configuration: TurntableConfiguration, vinylName: String, bundle: Bundle) -> String? {
         if let recordingPath = configuration.recordingPath {
             return recordingPath
         }
         
-        return bundle.resourceURL?.URLByAppendingPathComponent(vinylName).URLByAppendingPathExtension("json").path
+        return bundle.resourceURL?.appendingPathComponent(vinylName).appendingPathExtension("json").path
     }
     
-    public override var delegate: NSURLSessionDelegate? {
+    public override var delegate: URLSessionDelegate? {
         return nil
     }
 }
@@ -155,19 +155,19 @@ public final class Turntable: NSURLSession {
 
 extension Turntable {
     
-    public override func dataTaskWithURL(url: NSURL, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask {
-        let request = NSURLRequest(URL: url)
-        return dataTaskWithRequest(request, completionHandler: completionHandler)
+    public override func dataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> Foundation.URLSessionDataTask {
+        let request = URLRequest(url: url)
+        return dataTask(with: request, completionHandler: completionHandler)
     }
     
-    public override func dataTaskWithRequest(request: NSURLRequest, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionDataTask {
+    public override func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> Foundation.URLSessionDataTask {
         
         do {
             return try playVinyl(request: request, completionHandler: completionHandler) as URLSessionDataTask
         }
-        catch Error.TrackNotFound {
+        catch TurntableError.trackNotFound {
             if let session = recordingSession {
-                return session.dataTaskWithRequest(request, completionHandler: recordingHandler(request: request, completionHandler: completionHandler))
+                return session.dataTask(with: request, completionHandler: recordingHandler(request: request, completionHandler: completionHandler)) 
             }
             else {
                 errorHandler.handleTrackNotFound(request, playTracksUniquely: turntableConfiguration.playTracksUniquely)
@@ -180,14 +180,14 @@ extension Turntable {
         return URLSessionDataTask(completion: {})
     }
     
-    public override func uploadTaskWithRequest(request: NSURLRequest, fromData bodyData: NSData?, completionHandler: (NSData?, NSURLResponse?, NSError?) -> Void) -> NSURLSessionUploadTask {
+    public override func uploadTask(with request: URLRequest, from bodyData: Data?, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> Foundation.URLSessionUploadTask {
         
         do {
             return try playVinyl(request: request, fromData: bodyData, completionHandler: completionHandler) as URLSessionUploadTask
         }
-        catch Error.TrackNotFound {
+        catch TurntableError.trackNotFound {
             if let session = recordingSession {
-                return session.uploadTaskWithRequest(request, fromData: bodyData, completionHandler: recordingHandler(request: request, fromData: bodyData, completionHandler: completionHandler))
+                return session.uploadTask(with: request, from: bodyData, completionHandler: recordingHandler(request: request, fromData: bodyData, completionHandler: completionHandler))
             }
             else {
                 errorHandler.handleTrackNotFound(request, playTracksUniquely: turntableConfiguration.playTracksUniquely)
@@ -209,13 +209,13 @@ extension Turntable {
 
 extension Turntable {
     
-    public func loadVinyl(vinylName: String,  bundle: NSBundle = testingBundle()) {
+    public func loadVinyl(_ vinylName: String,  bundle: Bundle = testingBundle()) {
         let plastic = Turntable.createVinylPlastic(vinylName, bundle: bundle, recordingMode: turntableConfiguration.recordingMode)
         let vinyl = Vinyl(plastic: plastic ?? [])
         player = Turntable.createPlayer(vinyl, configuration: turntableConfiguration)
 
         switch turntableConfiguration.recordingMode {
-        case .MissingVinyl where plastic == nil, .MissingTracks:
+        case .missingVinyl where plastic == nil, .missingTracks:
             recorder = Recorder(wax: Wax(vinyl: vinyl), recordingPath: recordingPath(fromConfiguration: turntableConfiguration, vinylName: vinylName, bundle: bundle))
         default:
             recorder = nil
@@ -223,13 +223,13 @@ extension Turntable {
         }
     }
     
-    public func loadCassette(cassetteName: String,  bundle: NSBundle = testingBundle()) {
+    public func loadCassette(_ cassetteName: String,  bundle: Bundle = testingBundle()) {
         
         let vinyl = Vinyl(plastic: Turntable.createCassettePlastic(cassetteName, bundle: bundle))
         player = Turntable.createPlayer(vinyl, configuration: turntableConfiguration)
     }
     
-    public func loadVinyl(vinyl: Vinyl) {
+    public func loadVinyl(_ vinyl: Vinyl) {
         player = Turntable.createPlayer(vinyl, configuration: turntableConfiguration)
     }
 }
@@ -238,13 +238,13 @@ extension Turntable {
 
 extension Turntable {
     
-    private static func createPlayer(vinyl: Vinyl, configuration: TurntableConfiguration) -> Player {
+    fileprivate static func createPlayer(_ vinyl: Vinyl, configuration: TurntableConfiguration) -> Player {
         
         let trackMatchers = configuration.trackMatchersForVinyl(vinyl)
         return Player(vinyl: vinyl, trackMatchers: trackMatchers)
     }
     
-    private static func createCassettePlastic(cassetteName: String, bundle: NSBundle) -> Plastic {
+    fileprivate static func createCassettePlastic(_ cassetteName: String, bundle: Bundle) -> Plastic {
         
         guard let cassette: [String: AnyObject] = loadJSON(bundle, fileName: cassetteName) else {
             fatalError("💣 Cassette file \"\(cassetteName)\" not found 😩")
@@ -257,15 +257,15 @@ extension Turntable {
         return plastic
     }
     
-    private static func createVinylPlastic(vinylName: String, bundle: NSBundle, recordingMode: RecordingMode) -> Plastic? {
+    fileprivate static func createVinylPlastic(_ vinylName: String, bundle: Bundle, recordingMode: RecordingMode) -> Plastic? {
         if let plastic: Plastic = loadJSON(bundle, fileName: vinylName) {
             return plastic
         }
 
         switch recordingMode {
-        case .None, .MissingTracks:
+        case .none, .missingTracks:
             fatalError("💣 Vinyl file \"\(vinylName)\" not found 😩")
-        case .MissingVinyl:
+        case .missingVinyl:
             return nil
         }
     }

--- a/Vinyl/TurntableConfiguration.swift
+++ b/Vinyl/TurntableConfiguration.swift
@@ -62,7 +62,7 @@ public struct TurntableConfiguration {
         self.recordingMode = recordingMode
     }
     
-    func trackMatchersForVinyl(_ vinyl: Vinyl) -> [TrackMatcher] {
+    func trackMatchers(for vinyl: Vinyl) -> [TrackMatcher] {
         
         switch matchingStrategy {
             

--- a/Vinyl/TurntableConfiguration.swift
+++ b/Vinyl/TurntableConfiguration.swift
@@ -9,14 +9,14 @@
 import Foundation
 
 public enum MatchingStrategy {
-    case RequestAttributes(types: [RequestMatcherType], playTracksUniquely: Bool)
-    case TrackOrder
+    case requestAttributes(types: [RequestMatcherType], playTracksUniquely: Bool)
+    case trackOrder
 }
 
 public enum RecordingMode {
-    case None
-    case MissingTracks(recordingPath: String?)
-    case MissingVinyl(recordingPath: String?)
+    case none
+    case missingTracks(recordingPath: String?)
+    case missingVinyl(recordingPath: String?)
 }
 
 public struct TurntableConfiguration {
@@ -27,8 +27,8 @@ public struct TurntableConfiguration {
     var playTracksUniquely: Bool {
         get {
             switch matchingStrategy {
-            case .RequestAttributes(_, let playTracksUniquely): return playTracksUniquely
-            case .TrackOrder: return true
+            case .requestAttributes(_, let playTracksUniquely): return playTracksUniquely
+            case .trackOrder: return true
             }
         }
     }
@@ -36,7 +36,7 @@ public struct TurntableConfiguration {
     var recodingEnabled: Bool {
         get {
             switch recordingMode {
-            case .None:
+            case .none:
                 return false
             default:
                 return true
@@ -47,26 +47,26 @@ public struct TurntableConfiguration {
     var recordingPath: String? {
         get {
             switch recordingMode {
-            case .MissingVinyl(let path):
+            case .missingVinyl(let path):
                 return path
-            case .MissingTracks(let path):
+            case .missingTracks(let path):
                 return path
             default:
-                return .None
+                return .none
             }
         }
     }
     
-    public init(matchingStrategy: MatchingStrategy = .RequestAttributes(types: [.Method, .URL], playTracksUniquely: true), recordingMode: RecordingMode = .MissingVinyl(recordingPath: nil)) {
+    public init(matchingStrategy: MatchingStrategy = .requestAttributes(types: [.method, .url], playTracksUniquely: true), recordingMode: RecordingMode = .missingVinyl(recordingPath: nil)) {
         self.matchingStrategy = matchingStrategy
         self.recordingMode = recordingMode
     }
     
-    func trackMatchersForVinyl(vinyl: Vinyl) -> [TrackMatcher] {
+    func trackMatchersForVinyl(_ vinyl: Vinyl) -> [TrackMatcher] {
         
         switch matchingStrategy {
             
-        case .RequestAttributes(let types, let playTracksUniquely):
+        case .requestAttributes(let types, let playTracksUniquely):
             
             var trackMatchers: [TrackMatcher] = [ TypeTrackMatcher(requestMatcherTypes: types) ]
             
@@ -77,7 +77,7 @@ public struct TurntableConfiguration {
             
             return trackMatchers
             
-        case .TrackOrder:
+        case .trackOrder:
             return [ UniqueTrackMatcher(availableTracks: vinyl.tracks) ]
         }
     }

--- a/Vinyl/URLSessionDataTask.swift
+++ b/Vinyl/URLSessionDataTask.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public final class URLSessionDataTask: Foundation.URLSessionDataTask, URLSessionTaskType {
     
-    fileprivate let completion: (Void) -> Void
+    fileprivate let completion: () -> Void
     
-    init(completion: @escaping (Void) -> Void) {
+    init(completion: @escaping () -> Void) {
         self.completion = completion
     }
     

--- a/Vinyl/URLSessionDataTask.swift
+++ b/Vinyl/URLSessionDataTask.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-public final class URLSessionDataTask: NSURLSessionDataTask, URLSessionTaskType {
+public final class URLSessionDataTask: Foundation.URLSessionDataTask, URLSessionTaskType {
     
-    private let completion: Void -> Void
+    fileprivate let completion: (Void) -> Void
     
-    init(completion: Void -> Void) {
+    init(completion: @escaping (Void) -> Void) {
         self.completion = completion
     }
     

--- a/Vinyl/URLSessionTaskType.swift
+++ b/Vinyl/URLSessionTaskType.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 protocol URLSessionTaskType {
-    init(completion: Void -> Void)
+    init(completion: @escaping (Void) -> Void)
 }

--- a/Vinyl/URLSessionTaskType.swift
+++ b/Vinyl/URLSessionTaskType.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 protocol URLSessionTaskType {
-    init(completion: @escaping (Void) -> Void)
+    init(completion: @escaping () -> Void)
 }

--- a/Vinyl/URLSessionUploadTask.swift
+++ b/Vinyl/URLSessionUploadTask.swift
@@ -10,9 +10,9 @@ import Foundation
 
 public final class URLSessionUploadTask: Foundation.URLSessionUploadTask, URLSessionTaskType {
     
-    fileprivate let completion: (Void) -> Void
+    fileprivate let completion: () -> Void
     
-    init(completion: @escaping (Void) -> Void) {
+    init(completion: @escaping () -> Void) {
         self.completion = completion
     }
     

--- a/Vinyl/URLSessionUploadTask.swift
+++ b/Vinyl/URLSessionUploadTask.swift
@@ -8,11 +8,11 @@
 
 import Foundation
 
-public final class URLSessionUploadTask: NSURLSessionUploadTask, URLSessionTaskType {
+public final class URLSessionUploadTask: Foundation.URLSessionUploadTask, URLSessionTaskType {
     
-    private let completion: Void -> Void
+    fileprivate let completion: (Void) -> Void
     
-    init(completion: Void -> Void) {
+    init(completion: @escaping (Void) -> Void) {
         self.completion = completion
     }
     

--- a/Vinyl/Wax.swift
+++ b/Vinyl/Wax.swift
@@ -11,14 +11,14 @@ struct Wax {
     var tracks: [Track] = []
     
     init(vinyl: Vinyl) {
-        tracks.appendContentsOf(vinyl.tracks)
+        tracks.append(contentsOf: vinyl.tracks)
     }
     
     init(tracks: [Track]) {
-        self.tracks.appendContentsOf(tracks)
+        self.tracks.append(contentsOf: tracks)
     }
     
-    mutating func addTrack(track: Track) {
+    mutating func addTrack(_ track: Track) {
         tracks.append(track)
     }
 }

--- a/Vinyl/Wax.swift
+++ b/Vinyl/Wax.swift
@@ -18,7 +18,7 @@ struct Wax {
         self.tracks.append(contentsOf: tracks)
     }
     
-    mutating func addTrack(_ track: Track) {
+    mutating func add(track: Track) {
         tracks.append(track)
     }
 }

--- a/VinylTests/Mocked Handlers/MockedTrackedNotFoundErrorHandler.swift
+++ b/VinylTests/Mocked Handlers/MockedTrackedNotFoundErrorHandler.swift
@@ -15,9 +15,9 @@ final class MockedTrackedNotFoundErrorHandler: ErrorHandler {
             self.completion()
         }()
     
-    fileprivate let completion: (Void) -> Void
+    fileprivate let completion: () -> Void
     
-    init (completion: @escaping (Void) -> Void) {
+    init (completion: @escaping () -> Void) {
         self.completion = completion
     }
     

--- a/VinylTests/Mocked Handlers/MockedTrackedNotFoundErrorHandler.swift
+++ b/VinylTests/Mocked Handlers/MockedTrackedNotFoundErrorHandler.swift
@@ -11,21 +11,23 @@ import Foundation
 
 final class MockedTrackedNotFoundErrorHandler: ErrorHandler {
     
-    private let completion: Void -> Void
+    private lazy var __completeOnce: () = { () -> Void in
+            self.completion()
+        }()
     
-    init (completion: Void -> Void) {
+    fileprivate let completion: (Void) -> Void
+    
+    init (completion: @escaping (Void) -> Void) {
         self.completion = completion
     }
     
-    private var token: dispatch_once_t = 0
-    func handleTrackNotFound(request: Request, playTracksUniquely: Bool) {
+    fileprivate var token: Int = 0
+    func handleTrackNotFound(_ request: Request, playTracksUniquely: Bool) {
         
         // If this gets called multiple times and has an "expectation.fullfill()" it will crash
         // So we make sure it will only be called once.
         // It also makes sense, since in the DefaultErrorHandler this would call fatal_error (which is only called once)
-        dispatch_once(&token) { () -> Void in
-            self.completion()
-        }
+        _ = self.__completeOnce
     }
     
     func handleUnknownError() {

--- a/VinylTests/RequestMatcherRegistryTests.swift
+++ b/VinylTests/RequestMatcherRegistryTests.swift
@@ -40,7 +40,7 @@ class RequestMatcherRegistryTests: XCTestCase {
             var anotherRequest = URLRequest(url: URL(string: url + path + params)!)
             anotherRequest.httpBody = commonData
             
-            return registry.matchableRequests(aRequest, anotherRequest: anotherRequest)
+            return registry.matchableRequests(request: aRequest, with: anotherRequest)
         }
         
         property("Requests with identical headers should match") <- forAllNoShrink(
@@ -55,7 +55,7 @@ class RequestMatcherRegistryTests: XCTestCase {
             var anotherRequest = URLRequest(url: URL(string: url)!)
             anotherRequest.allHTTPHeaderFields = headers
             
-            return registry.matchableRequests(aRequest, anotherRequest: anotherRequest)
+            return registry.matchableRequests(request: aRequest, with: anotherRequest)
         }
         
         property("Requests with mixed values shouldn't match") <- forAllNoShrink(
@@ -77,7 +77,7 @@ class RequestMatcherRegistryTests: XCTestCase {
                 var anotherRequest = URLRequest(url: URL(string: url)!)
                 anotherRequest.allHTTPHeaderFields = upperHeaders
                 
-                return registry.matchableRequests(aRequest, anotherRequest: anotherRequest)
+                return registry.matchableRequests(request: aRequest, with: anotherRequest)
             }
         }.expectFailure
         
@@ -99,7 +99,7 @@ class RequestMatcherRegistryTests: XCTestCase {
                 var anotherRequest = URLRequest(url: URL(string: url)!)
                 anotherRequest.allHTTPHeaderFields = upperHeaders
                 
-                return registry.matchableRequests(aRequest, anotherRequest: anotherRequest)
+                return registry.matchableRequests(request: aRequest, with: anotherRequest)
             }
         }
     }

--- a/VinylTests/RequestMatcherRegistryTests.swift
+++ b/VinylTests/RequestMatcherRegistryTests.swift
@@ -13,20 +13,20 @@ import SwiftCheck
 class RequestMatcherRegistryTests: XCTestCase {
     func testProperties() {
         property("Requests with identical paths and query parameters should match") <- forAllNoShrink(
-              Gen<RequestMatcherType>.fromElementsOf([RequestMatcherType.Path, .Query, .Body])
+              Gen<RequestMatcherType>.fromElements(of: [RequestMatcherType.path, .query, .body])
             , urlStringGen
             , urlPathGen
             , pathParameterGen
             , Optional<String>.arbitrary
         ) { (type, url, path, params, body) in
             let registry = RequestMatcherRegistry(types: [type])
-            let commonData = body?.dataUsingEncoding(NSUTF8StringEncoding)
+            let commonData = body?.data(using: .utf8)
             
-            let aRequest = NSMutableURLRequest(URL: NSURL(string: url + path + params )!)			
-            aRequest.HTTPBody = commonData
+            var aRequest = URLRequest(url: URL(string: url + path + params )!)
+            aRequest.httpBody = commonData
             
-            let anotherRequest = NSMutableURLRequest(URL: NSURL(string: url + path + params)!)
-            anotherRequest.HTTPBody = commonData
+            var anotherRequest = URLRequest(url: URL(string: url + path + params)!)
+            anotherRequest.httpBody = commonData
             
             return registry.matchableRequests(aRequest, anotherRequest: anotherRequest)
         }
@@ -35,12 +35,12 @@ class RequestMatcherRegistryTests: XCTestCase {
               urlStringGen
             , HTTPHeaders.arbitrary
         ) { (url, headers) in
-            let registry = RequestMatcherRegistry(types: [.Headers])
+            let registry = RequestMatcherRegistry(types: [.headers])
             
-            let aRequest = NSMutableURLRequest(URL: NSURL(string: url)!)
+            var aRequest = URLRequest(url: URL(string: url)!)
             aRequest.allHTTPHeaderFields = headers
             
-            let anotherRequest = NSMutableURLRequest(URL: NSURL(string: url)!)
+            var anotherRequest = URLRequest(url: URL(string: url)!)
             anotherRequest.allHTTPHeaderFields = headers
             
             return registry.matchableRequests(aRequest, anotherRequest: anotherRequest)
@@ -51,17 +51,25 @@ class RequestMatcherRegistryTests: XCTestCase {
             , Positive<Int>.arbitrary
         ) { (url, size) in
             return forAllNoShrink(
-                  lowerStringGen.proliferateSized(size.getPositive)
-                , lowerStringGen.proliferateSized(size.getPositive)
+                  lowerStringGen.proliferate(withSize: size.getPositive)
+                , lowerStringGen.proliferate(withSize: size.getPositive)
             ) { (keys, vals) in
-                let headers = HTTPHeaders(zip(keys, vals.sort(>)))
-                let upperHeaders = HTTPHeaders(zip(keys, vals.sort(<)))
-                let registry = RequestMatcherRegistry(types: [.Headers])
+                var headers = HTTPHeaders(minimumCapacity: keys.count)
+                for (key, value) in zip(keys, vals.sorted { $0.caseInsensitiveCompare($1) == .orderedDescending }) {
+                    headers[key] = value
+                }
                 
-                let aRequest = NSMutableURLRequest(URL: NSURL(string: url)!)
+                var upperHeaders = HTTPHeaders(minimumCapacity: keys.count)
+                for (key, value) in zip(keys, vals.sorted()) {
+                    upperHeaders[key] = value
+                }
+                
+                let registry = RequestMatcherRegistry(types: [.headers])
+                
+                var aRequest = URLRequest(url: URL(string: url)!)
                 aRequest.allHTTPHeaderFields = headers
                 
-                let anotherRequest = NSMutableURLRequest(URL: NSURL(string: url)!)
+                var anotherRequest = URLRequest(url: URL(string: url)!)
                 anotherRequest.allHTTPHeaderFields = upperHeaders
                 
                 return registry.matchableRequests(aRequest, anotherRequest: anotherRequest)
@@ -73,17 +81,23 @@ class RequestMatcherRegistryTests: XCTestCase {
             , Positive<Int>.arbitrary
         ) { (url, size) in
             return forAllNoShrink(
-                  lowerStringGen.proliferateSized(size.getPositive)
-                , lowerStringGen.proliferateSized(size.getPositive)
+                  lowerStringGen.proliferate(withSize: size.getPositive)
+                , lowerStringGen.proliferate(withSize: size.getPositive)
             ) { (keys, vals) in
-                let headers = HTTPHeaders(zip(keys, vals))
-                let upperHeaders = HTTPHeaders(headers.map { (l, r) in (l.uppercaseString, r.uppercaseString) })
-                let registry = RequestMatcherRegistry(types: [.Headers])
+                var headers = HTTPHeaders(minimumCapacity: keys.count)
+                for (key, value) in zip(keys, vals) {
+                    headers[key] = value
+                }
+                var upperHeaders = HTTPHeaders(minimumCapacity: keys.count)
+                for (key, value) in zip(keys, vals) {
+                    upperHeaders[key.uppercased()] = value.uppercased()
+                }
+                let registry = RequestMatcherRegistry(types: [.headers])
                 
-                let aRequest = NSMutableURLRequest(URL: NSURL(string: url)!)
+                var aRequest = URLRequest(url: URL(string: url)!)
                 aRequest.allHTTPHeaderFields = headers
                 
-                let anotherRequest = NSMutableURLRequest(URL: NSURL(string: url)!)
+                var anotherRequest = URLRequest(url: URL(string: url)!)
                 anotherRequest.allHTTPHeaderFields = upperHeaders
                 
                 return registry.matchableRequests(aRequest, anotherRequest: anotherRequest)

--- a/VinylTests/RequestMatcherRegistryTests.swift
+++ b/VinylTests/RequestMatcherRegistryTests.swift
@@ -12,8 +12,7 @@ import SwiftCheck
 
 extension Dictionary {
     init<S : Sequence>(_ pairs : S)  {
-        self.init()
-        
+        self.init()        
         var g = pairs.makeIterator()
         while let (k, v) : (Key, Value) = g.next() as! (Key, Value)? {
             self[k] = v

--- a/VinylTests/TrackTests.swift
+++ b/VinylTests/TrackTests.swift
@@ -13,7 +13,7 @@ import SwiftCheck
 class TrackTests: XCTestCase {
     func testProperties() {
         property("Bad tracks contain no body") <- forAllNoShrink(urlStringGen) { url in
-            let track = TrackFactory.createBadTrack(URL(string: url)!, statusCode: 400)
+            let track = TrackFactory.createBadTrack(url: URL(string: url)!, statusCode: 400)
             return track.response.urlResponse?.statusCode == 400
                 && track.response.urlResponse?.url?.absoluteString == url
                 && track.request.url?.absoluteString == url
@@ -23,7 +23,7 @@ class TrackTests: XCTestCase {
         property("Bad tracks created with an error reflect that error") <- forAllNoShrink(urlStringGen) { url in
             return forAll { (domain : String, code : Positive<Int>) in
                 let error = NSError(domain: domain, code: code.getPositive, userInfo: nil)
-                let track = TrackFactory.createBadTrack(URL(string: url)!, statusCode: code.getPositive, error: error)
+                let track = TrackFactory.createBadTrack(url: URL(string: url)!, statusCode: code.getPositive, error: error)
                 
                 return track.response.urlResponse?.statusCode == code.getPositive
                     && track.response.error?.localizedDescription == error.localizedDescription
@@ -36,7 +36,7 @@ class TrackTests: XCTestCase {
         property("Error tracks created without a status code") <- forAllNoShrink(urlStringGen) { url in
             return forAll { (domain : String, code : Positive<Int>) in
                 let error = NSError(domain: domain, code: code.getPositive, userInfo: nil)
-                let track = TrackFactory.createErrorTrack(URL(string: url)!, error: error)
+                let track = TrackFactory.createErrorTrack(url: URL(string: url)!, error: error)
 
                 return track.response.urlResponse == .none
                     && track.response.error?.localizedDescription == error.localizedDescription
@@ -51,7 +51,7 @@ class TrackTests: XCTestCase {
             , HTTPHeaders.arbitrary
             ) { (url, body, headers) in
                 let data = body.data(using: .utf8)!
-                let track = TrackFactory.createValidTrack(URL(string: url)!, body: data, headers: headers)
+                let track = TrackFactory.createValidTrack(url: URL(string: url)!, body: data, headers: headers)
                 
                 return isValidTrack(track, data: data, headers: headers, url: url)
         }
@@ -63,7 +63,7 @@ class TrackTests: XCTestCase {
             ) { (url, body, headers) in
                 
                 guard let data = Data(base64Encoded: body, options: .ignoreUnknownCharacters) else { return true }
-                let track = TrackFactory.createValidTrackFromBase64(URL(string: url)!, bodyString:body, headers: headers)
+                let track = TrackFactory.createValidTrack(url: URL(string: url)!, base64Body:body, headers: headers)
                 
                 return isValidTrack(track, data: data, headers: headers, url: url)
         }
@@ -75,7 +75,7 @@ class TrackTests: XCTestCase {
             ) { (url, body, headers) in
                 
                 guard let data = body.data(using: .utf8) else { return true}
-                let track = TrackFactory.createValidTrackFromUTF8(URL(string: url)!, bodyString:body, headers: headers)
+                let track = TrackFactory.createValidTrack(url: URL(string: url)!, utf8Body:body, headers: headers)
                 
                 return isValidTrack(track, data: data, headers: headers, url: url)
         }
@@ -87,7 +87,7 @@ class TrackTests: XCTestCase {
             ) { (url, body, headers) in
                 
                 guard let data = try? JSONSerialization.data(withJSONObject: body, options: .prettyPrinted) else { return true}
-                let track = TrackFactory.createValidTrackFromJSON(URL(string: url)!, json:body, headers: headers)
+                let track = TrackFactory.createValidTrack(url: URL(string: url)!, jsonBody:body, headers: headers)
                 
                 return isValidTrack(track, data: data, headers: headers, url: url)
         }

--- a/VinylTests/TrackTests.swift
+++ b/VinylTests/TrackTests.swift
@@ -26,7 +26,8 @@ class TrackTests: XCTestCase {
                 let track = TrackFactory.createBadTrack(url: URL(string: url)!, statusCode: code.getPositive, error: error)
                 
                 return track.response.urlResponse?.statusCode == code.getPositive
-                    && track.response.error?.localizedDescription == error.localizedDescription
+                    && track.response.error?._domain == error._domain
+                    && track.response.error?._code == error._code
                     && track.response.urlResponse?.url?.absoluteString == url
                     && track.request.url?.absoluteString == url
                     && track.response.body == nil
@@ -39,7 +40,8 @@ class TrackTests: XCTestCase {
                 let track = TrackFactory.createErrorTrack(url: URL(string: url)!, error: error)
 
                 return track.response.urlResponse == .none
-                    && track.response.error?.localizedDescription == error.localizedDescription
+                    && track.response.error?._domain == error._domain
+                    && track.response.error?._code == error._code
                     && track.request.url?.absoluteString == url
                     && track.response.body == nil
             }

--- a/VinylTests/TrackTests.swift
+++ b/VinylTests/TrackTests.swift
@@ -13,22 +13,22 @@ import SwiftCheck
 class TrackTests: XCTestCase {
     func testProperties() {
         property("Bad tracks contain no body") <- forAllNoShrink(urlStringGen) { url in
-            let track = TrackFactory.createBadTrack(NSURL(string: url)!, statusCode: 400)
+            let track = TrackFactory.createBadTrack(URL(string: url)!, statusCode: 400)
             return track.response.urlResponse?.statusCode == 400
-                && track.response.urlResponse?.URL?.absoluteString == url
-                && track.request.URL?.absoluteString == url
+                && track.response.urlResponse?.url?.absoluteString == url
+                && track.request.url?.absoluteString == url
                 && track.response.body == nil
         }
         
         property("Bad tracks created with an error reflect that error") <- forAllNoShrink(urlStringGen) { url in
             return forAll { (domain : String, code : Positive<Int>) in
                 let error = NSError(domain: domain, code: code.getPositive, userInfo: nil)
-                let track = TrackFactory.createBadTrack(NSURL(string: url)!, statusCode: code.getPositive, error: error)
+                let track = TrackFactory.createBadTrack(URL(string: url)!, statusCode: code.getPositive, error: error)
                 
                 return track.response.urlResponse?.statusCode == code.getPositive
-                    && track.response.error == error
-                    && track.response.urlResponse?.URL?.absoluteString == url
-                    && track.request.URL?.absoluteString == url
+                    && track.response.error?.localizedDescription == error.localizedDescription
+                    && track.response.urlResponse?.url?.absoluteString == url
+                    && track.request.url?.absoluteString == url
                     && track.response.body == nil
             }
         }
@@ -36,11 +36,11 @@ class TrackTests: XCTestCase {
         property("Error tracks created without a status code") <- forAllNoShrink(urlStringGen) { url in
             return forAll { (domain : String, code : Positive<Int>) in
                 let error = NSError(domain: domain, code: code.getPositive, userInfo: nil)
-                let track = TrackFactory.createErrorTrack(NSURL(string: url)!, error: error)
+                let track = TrackFactory.createErrorTrack(URL(string: url)!, error: error)
 
-                return track.response.urlResponse == .None
-                    && track.response.error == error
-                    && track.request.URL?.absoluteString == url
+                return track.response.urlResponse == .none
+                    && track.response.error?.localizedDescription == error.localizedDescription
+                    && track.request.url?.absoluteString == url
                     && track.response.body == nil
             }
         }
@@ -50,8 +50,8 @@ class TrackTests: XCTestCase {
             , String.arbitrary
             , HTTPHeaders.arbitrary
             ) { (url, body, headers) in
-                let data = body.dataUsingEncoding(NSUTF8StringEncoding)!
-                let track = TrackFactory.createValidTrack(NSURL(string: url)!, body: data, headers: headers)
+                let data = body.data(using: .utf8)!
+                let track = TrackFactory.createValidTrack(URL(string: url)!, body: data, headers: headers)
                 
                 return isValidTrack(track, data: data, headers: headers, url: url)
         }
@@ -62,8 +62,8 @@ class TrackTests: XCTestCase {
             , HTTPHeaders.arbitrary
             ) { (url, body, headers) in
                 
-                guard let data = NSData(base64EncodedString: body, options: .IgnoreUnknownCharacters) else { return true }
-                let track = TrackFactory.createValidTrackFromBase64(NSURL(string: url)!, bodyString:body, headers: headers)
+                guard let data = Data(base64Encoded: body, options: .ignoreUnknownCharacters) else { return true }
+                let track = TrackFactory.createValidTrackFromBase64(URL(string: url)!, bodyString:body, headers: headers)
                 
                 return isValidTrack(track, data: data, headers: headers, url: url)
         }
@@ -74,8 +74,8 @@ class TrackTests: XCTestCase {
             , HTTPHeaders.arbitrary
             ) { (url, body, headers) in
                 
-                guard let data = body.dataUsingEncoding(NSUTF8StringEncoding) else { return true}
-                let track = TrackFactory.createValidTrackFromUTF8(NSURL(string: url)!, bodyString:body, headers: headers)
+                guard let data = body.data(using: .utf8) else { return true}
+                let track = TrackFactory.createValidTrackFromUTF8(URL(string: url)!, bodyString:body, headers: headers)
                 
                 return isValidTrack(track, data: data, headers: headers, url: url)
         }
@@ -86,19 +86,19 @@ class TrackTests: XCTestCase {
             , HTTPHeaders.arbitrary
             ) { (url, body, headers) in
                 
-                guard let data = try? NSJSONSerialization.dataWithJSONObject(body, options: .PrettyPrinted) else { return true}
-                let track = TrackFactory.createValidTrackFromJSON(NSURL(string: url)!, json:body, headers: headers)
+                guard let data = try? JSONSerialization.data(withJSONObject: body, options: .prettyPrinted) else { return true}
+                let track = TrackFactory.createValidTrackFromJSON(URL(string: url)!, json:body, headers: headers)
                 
                 return isValidTrack(track, data: data, headers: headers, url: url)
         }
     }
 }
 
-func isValidTrack(track: Track, data: NSData, headers: HTTPHeaders, url: String) -> Bool {
+func isValidTrack(_ track: Track, data: Data, headers: HTTPHeaders, url: String) -> Bool {
     
     return track.response.urlResponse?.statusCode == 200
-        && track.response.body!.isEqualToData(data)
+        && (track.response.body! == data)
         && track.response.urlResponse?.allHeaderFields as! HTTPHeaders == headers
-        && track.response.urlResponse?.URL?.absoluteString == url
-        && track.request.URL?.absoluteString == url
+        && track.response.urlResponse?.url?.absoluteString == url
+        && track.request.url?.absoluteString == url
 }

--- a/VinylTests/TurntableTests.swift
+++ b/VinylTests/TurntableTests.swift
@@ -191,13 +191,13 @@ class TurntableTests: XCTestCase {
         
         let tracks = [
             TrackFactory.createValidTrack(
-                URL(string: "http://api.test.com")!,
+                url: URL(string: "http://api.test.com")!,
                 body: "hello".data(using: String.Encoding.utf8),
                 headers: [:])
         ]
         
         let vinyl = Vinyl(tracks: tracks)
-        turntable.loadVinyl(vinyl)
+        turntable.load(vinyl: vinyl)
         singleCallTest(turntable)
     }
     
@@ -206,7 +206,7 @@ class TurntableTests: XCTestCase {
         let turntableConfiguration = TurntableConfiguration()
         let turntable = Turntable(configuration: turntableConfiguration)
         
-        turntable.loadVinyl("vinyl_single")
+        turntable.load(vinyl: "vinyl_single")
         singleCallTest(turntable)
     }
     
@@ -215,7 +215,7 @@ class TurntableTests: XCTestCase {
         let turntableConfiguration = TurntableConfiguration()
         let turntable = Turntable(configuration: turntableConfiguration)
         
-        turntable.loadCassette("dvr_single")
+        turntable.load(cassette: "dvr_single")
         singleCallTest(turntable)
     }
     
@@ -290,15 +290,15 @@ class TurntableTests: XCTestCase {
         
         var tracks = [
             TrackFactory.createValidTrack(
-                URL(string: "http://feelGoodINC.com/request/2")!,
+                url: URL(string: "http://feelGoodINC.com/request/2")!,
                 body: nil,
                 headers: [ "header1": "value1" ]),
             TrackFactory.createValidTrack(
-                URL(string: "http://feelGoodINC.com/request/1")!,
+                url: URL(string: "http://feelGoodINC.com/request/1")!,
                 body: nil,
                 headers: [ "header1": "value1", "header2": "value2" ]),
             TrackFactory.createValidTrack(
-                URL(string: "https://rand.com/")!)
+                url: URL(string: "https://rand.com/")!)
         ]
         
         var request1 = URLRequest(url: URL(string: "http://random.com")!)

--- a/VinylTests/TurntableTests.swift
+++ b/VinylTests/TurntableTests.swift
@@ -41,63 +41,63 @@ class TurntableTests: XCTestCase {
     
     func test_Vinyl_multiple_differentMethods() {
         
-        let expectation = self.expectationWithDescription("Expected callback to have the correct URL")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "Expected callback to have the correct URL")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
         let turntable = Turntable(
             vinylName: "vinyl_multiple",
-            turntableConfiguration: TurntableConfiguration(matchingStrategy: .RequestAttributes(types: [.URL], playTracksUniquely: true)))
+            turntableConfiguration: TurntableConfiguration(matchingStrategy: .requestAttributes(types: [.url], playTracksUniquely: true)))
         
-        let request1 = NSMutableURLRequest(URL: NSURL(string: "http://api.test1.com")!)
-        request1.HTTPMethod = "POST"
+        var request1 = URLRequest(url: URL(string: "http://api.test1.com")!)
+        request1.httpMethod = "POST"
         
-        let request2 = NSMutableURLRequest(URL: NSURL(string: "http://api.test2.com")!)
-        request2.HTTPMethod = "POST"
+        var request2 = URLRequest(url: URL(string: "http://api.test2.com")!)
+        request2.httpMethod = "POST"
         
         var numberOfCalls = 0
-        let checker: (NSData?, NSURLResponse?, NSError?) -> () = { (data, response, anError) in
+        let checker: (Data?, URLResponse?, Error?) -> () = { (data, response, anError) in
             
-            guard let httpResponse = response as? NSHTTPURLResponse else { fatalError("\(response) should be a NSHTTPURLResponse") }
+            guard let httpResponse = response as? HTTPURLResponse else { fatalError("\(response) should be a NSHTTPURLResponse") }
             
             switch numberOfCalls {
             case 0:
-                XCTAssertEqual(httpResponse.URL!.absoluteString, "http://api.test1.com")
+                XCTAssertEqual(httpResponse.url!.absoluteString, "http://api.test1.com")
                 numberOfCalls += 1
             case 1:
-                XCTAssertEqual(httpResponse.URL!.absoluteString, "http://api.test2.com")
+                XCTAssertEqual(httpResponse.url!.absoluteString, "http://api.test2.com")
                 expectation.fulfill()
             default: break
             }
         }
         
-        turntable.dataTaskWithRequest(request1, completionHandler: checker).resume()
-        turntable.dataTaskWithRequest(request2, completionHandler: checker).resume()
+        turntable.dataTask(with: request1, completionHandler: checker).resume()
+        turntable.dataTask(with: request2, completionHandler: checker).resume()
     }
     
     func test_Vinyl_multiple_andNotUniquely() {
         
-        let expectation = self.expectationWithDescription("Expected callback to have the correct URL")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "Expected callback to have the correct URL")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
         let turntable = Turntable(
             vinylName: "vinyl_multiple",
-            turntableConfiguration: TurntableConfiguration(matchingStrategy: .RequestAttributes(types: [.URL], playTracksUniquely: false)))
+            turntableConfiguration: TurntableConfiguration(matchingStrategy: .requestAttributes(types: [.url], playTracksUniquely: false)))
         
         let url1String = "http://api.test1.com"
         let url2String = "http://api.test2.com"
         
         var numberOfCalls = 0
-        let checker: (NSData?, NSURLResponse?, NSError?) -> () = { (data, response, anError) in
+        let checker: (Data?, URLResponse?, Error?) -> () = { (data, response, anError) in
             
-            guard let httpResponse = response as? NSHTTPURLResponse else { fatalError("\(response) should be a NSHTTPURLResponse") }
+            guard let httpResponse = response as? HTTPURLResponse else { fatalError("\(response) should be a NSHTTPURLResponse") }
             
             numberOfCalls += 1
             
             switch numberOfCalls {
             case 1:
-                XCTAssertEqual(httpResponse.URL!.absoluteString, url1String)
+                XCTAssertEqual(httpResponse.url!.absoluteString, url1String)
             case 2...4:
-                XCTAssertEqual(httpResponse.URL!.absoluteString, url2String)
+                XCTAssertEqual(httpResponse.url!.absoluteString, url2String)
                 if numberOfCalls == 4 {
                     expectation.fulfill()
                 }
@@ -105,21 +105,21 @@ class TurntableTests: XCTestCase {
             }
         }
         
-        turntable.dataTaskWithURL(NSURL(string: url1String)!, completionHandler: checker).resume()
-        turntable.dataTaskWithURL(NSURL(string: url2String)!, completionHandler: checker).resume()
-        turntable.dataTaskWithURL(NSURL(string: url2String)!, completionHandler: checker).resume()
-        turntable.dataTaskWithURL(NSURL(string: url2String)!, completionHandler: checker).resume()
+        turntable.dataTask(with: URL(string: url1String)!, completionHandler: checker).resume()
+        turntable.dataTask(with: URL(string: url2String)!, completionHandler: checker).resume()
+        turntable.dataTask(with: URL(string: url2String)!, completionHandler: checker).resume()
+        turntable.dataTask(with: URL(string: url2String)!, completionHandler: checker).resume()
     }
     
     
     func test_Vinyl_multiple_uniquely() {
         
-        let expectation = self.expectationWithDescription("Expected callback to have the correct URL")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "Expected callback to have the correct URL")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
         let turntable = Turntable(
             vinylName: "vinyl_multiple",
-            turntableConfiguration: TurntableConfiguration(matchingStrategy: .RequestAttributes(types: [.URL], playTracksUniquely: true)))
+            turntableConfiguration: TurntableConfiguration(matchingStrategy: .requestAttributes(types: [.url], playTracksUniquely: true)))
         
         let url1String = "http://api.test1.com"
         let url2String = "http://api.test2.com"
@@ -128,16 +128,16 @@ class TurntableTests: XCTestCase {
         turntable.errorHandler = mockedTrackedNotFound
         
         var numberOfCalls = 0
-        let checker: (NSData?, NSURLResponse?, NSError?) -> () = { (data, response, anError) in
+        let checker: (Data?, URLResponse?, Error?) -> () = { (data, response, anError) in
             
-            guard let httpResponse = response as? NSHTTPURLResponse else { fatalError("\(response) should be a NSHTTPURLResponse") }
+            guard let httpResponse = response as? HTTPURLResponse else { fatalError("\(response) should be a NSHTTPURLResponse") }
             
             switch numberOfCalls {
             case 0:
-                XCTAssertEqual(httpResponse.URL!.absoluteString, url1String)
+                XCTAssertEqual(httpResponse.url!.absoluteString, url1String)
                 numberOfCalls += 1
             case 1:
-                XCTAssertEqual(httpResponse.URL!.absoluteString, url2String)
+                XCTAssertEqual(httpResponse.url!.absoluteString, url2String)
                 numberOfCalls += 1
             case 2:
                 fatalError("This shouldn't be reached")
@@ -145,37 +145,37 @@ class TurntableTests: XCTestCase {
             }
         }
         
-        turntable.dataTaskWithURL(NSURL(string: url1String)!, completionHandler: checker).resume()
-        turntable.dataTaskWithURL(NSURL(string: url2String)!, completionHandler: checker).resume()
-        turntable.dataTaskWithURL(NSURL(string: url2String)!, completionHandler: checker).resume()
-        turntable.dataTaskWithURL(NSURL(string: url2String)!, completionHandler: checker).resume()
-        turntable.dataTaskWithURL(NSURL(string: url2String)!, completionHandler: checker).resume()
+        turntable.dataTask(with: URL(string: url1String)!, completionHandler: checker).resume()
+        turntable.dataTask(with: URL(string: url2String)!, completionHandler: checker).resume()
+        turntable.dataTask(with: URL(string: url2String)!, completionHandler: checker).resume()
+        turntable.dataTask(with: URL(string: url2String)!, completionHandler: checker).resume()
+        turntable.dataTask(with: URL(string: url2String)!, completionHandler: checker).resume()
     }
     
     func test_Vinyl_upload() {
         
-        let expectation = self.expectationWithDescription("Expected callback to have the correct response and data")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "Expected callback to have the correct response and data")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
         let turntable = Turntable(
             vinylName: "vinyl_upload",
-            turntableConfiguration: TurntableConfiguration(matchingStrategy: .RequestAttributes(types: [.Method, .URL, .Body], playTracksUniquely: true)))
+            turntableConfiguration: TurntableConfiguration(matchingStrategy: .requestAttributes(types: [.method, .url, .body], playTracksUniquely: true)))
         
         let urlString = "http://api.test.com"
-        let request = NSMutableURLRequest(URL: NSURL(string: urlString)!)
-        request.HTTPMethod = "POST"
+        var request = URLRequest(url: URL(string: urlString)!)
+        request.httpMethod = "POST"
         request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        let data = try! NSJSONSerialization.dataWithJSONObject(["username": "ziggy", "password": "stardust"], options: [])
+        let data = try! JSONSerialization.data(withJSONObject: ["username": "ziggy", "password": "stardust"], options: [])
         
-        turntable.uploadTaskWithRequest(request, fromData: data, completionHandler: { (data, response, error) in
+        turntable.uploadTask(with: request, from: data, completionHandler: { (data, response, error) in
             XCTAssertNil(error)
             
-            guard let httpResponse = response as? NSHTTPURLResponse else { fatalError("\(response) should be a NSHTTPURLResponse") }
+            guard let httpResponse = response as? HTTPURLResponse else { fatalError("\(response) should be a NSHTTPURLResponse") }
             
-            let body: AnyObject = ["token": "thespidersfrommars"]
-            let responseBody = try! NSJSONSerialization.JSONObjectWithData(data!, options: [])
+            let body = ["token": "thespidersfrommars"]
+            let responseBody = try! JSONSerialization.jsonObject(with: data!, options: []) as AnyObject
             
-            XCTAssertEqual(httpResponse.URL!.absoluteString, urlString)
+            XCTAssertEqual(httpResponse.url!.absoluteString, urlString)
             XCTAssertEqual(httpResponse.statusCode, 200)
             XCTAssertTrue(responseBody.isEqual(body))
             XCTAssertNotNil(httpResponse.allHeaderFields)
@@ -191,8 +191,8 @@ class TurntableTests: XCTestCase {
         
         let tracks = [
             TrackFactory.createValidTrack(
-                NSURL(string: "http://api.test.com")!,
-                body: "hello".dataUsingEncoding(NSUTF8StringEncoding),
+                URL(string: "http://api.test.com")!,
+                body: "hello".data(using: String.Encoding.utf8),
                 headers: [:])
         ]
         
@@ -221,62 +221,62 @@ class TurntableTests: XCTestCase {
     
     //MARK: Aux methods
     
-    private func singleCallTest(turntable: Turntable) {
+    fileprivate func singleCallTest(_ turntable: Turntable) {
         
-        let expectation = self.expectationWithDescription("Expected callback to have the correct URL")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "Expected callback to have the correct URL")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
         let urlString = "http://api.test.com"
         
-        turntable.dataTaskWithURL(NSURL(string: urlString)!) { (data, response, anError) in
+        turntable.dataTask(with: URL(string: urlString)!, completionHandler: { (data, response, anError) in
             
             XCTAssertNil(anError)
             
-            guard let httpResponse = response as? NSHTTPURLResponse else { fatalError("\(response) should be a NSHTTPURLResponse") }
+            guard let httpResponse = response as? HTTPURLResponse else { fatalError("\(response) should be a NSHTTPURLResponse") }
             
-            let body = "hello".dataUsingEncoding(NSUTF8StringEncoding)!
+            let body = "hello".data(using: String.Encoding.utf8)!
             
-            XCTAssertEqual(httpResponse.URL!.absoluteString, urlString)
+            XCTAssertEqual(httpResponse.url!.absoluteString, urlString)
             XCTAssertEqual(httpResponse.statusCode, 200)
-            XCTAssertTrue(data!.isEqualToData(body))
+            XCTAssertTrue(data! == body)
             XCTAssertNotNil(httpResponse.allHeaderFields)
             
             expectation.fulfill()
-            }.resume()
+            }) .resume()
     }
     
-    private func multipleCallTest(turntable: Turntable) {
+    fileprivate func multipleCallTest(_ turntable: Turntable) {
         
-        let expectation = self.expectationWithDescription("Expected callback to have the correct URL")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "Expected callback to have the correct URL")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
         let url1String = "http://api.test1.com"
         let url2String = "http://api.test2.com"
         
         var numberOfCalls = 0
-        let checker: (NSData?, NSURLResponse?, NSError?) -> () = { (data, response, anError) in
+        let checker: (Data?, URLResponse?, Error?) -> () = { (data, response, anError) in
             
-            guard let httpResponse = response as? NSHTTPURLResponse else { fatalError("\(response) should be a NSHTTPURLResponse") }
+            guard let httpResponse = response as? HTTPURLResponse else { fatalError("\(response) should be a NSHTTPURLResponse") }
             
             switch numberOfCalls {
             case 0:
-                XCTAssertEqual(httpResponse.URL!.absoluteString, url1String)
+                XCTAssertEqual(httpResponse.url!.absoluteString, url1String)
                 numberOfCalls += 1
             case 1:
-                XCTAssertEqual(httpResponse.URL!.absoluteString, url2String)
+                XCTAssertEqual(httpResponse.url!.absoluteString, url2String)
                 expectation.fulfill()
             default: break
             }
         }
         
-        turntable.dataTaskWithURL(NSURL(string: url1String)!, completionHandler: checker).resume()
-        turntable.dataTaskWithURL(NSURL(string: url2String)!, completionHandler: checker).resume()
+        turntable.dataTask(with: URL(string: url1String)!, completionHandler: checker).resume()
+        turntable.dataTask(with: URL(string: url2String)!, completionHandler: checker).resume()
     }
     
-    private func prepPathForRecording(vinylName: String) -> String {
-        let testBundle = NSBundle.allBundles().filter() { $0.bundlePath.hasSuffix(".xctest") }.first!
-        let path = testBundle.resourceURL?.URLByAppendingPathComponent(vinylName).URLByAppendingPathExtension("json").path
-        let _ = try? NSFileManager.defaultManager().removeItemAtPath(path!)
+    fileprivate func prepPathForRecording(_ vinylName: String) -> String {
+        let testBundle = Bundle.allBundles.filter() { $0.bundlePath.hasSuffix(".xctest") }.first!
+        let path = testBundle.resourceURL?.appendingPathComponent(vinylName).appendingPathExtension("json").path
+        let _ = try? FileManager.default.removeItem(atPath: path!)
 
         return path!
     }
@@ -285,34 +285,34 @@ class TurntableTests: XCTestCase {
     
     func test_Vinyl_withTrackOrder() {
         
-        let expectation = self.expectationWithDescription("All tracks should be placed in order")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "All tracks should be placed in order")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
         var tracks = [
             TrackFactory.createValidTrack(
-                NSURL(string: "http://feelGoodINC.com/request/2")!,
+                URL(string: "http://feelGoodINC.com/request/2")!,
                 body: nil,
                 headers: [ "header1": "value1" ]),
             TrackFactory.createValidTrack(
-                NSURL(string: "http://feelGoodINC.com/request/1")!,
+                URL(string: "http://feelGoodINC.com/request/1")!,
                 body: nil,
                 headers: [ "header1": "value1", "header2": "value2" ]),
             TrackFactory.createValidTrack(
-                NSURL(string: "https://rand.com/")!)
+                URL(string: "https://rand.com/")!)
         ]
         
-        let request1 = NSMutableURLRequest(URL: NSURL(string: "http://random.com")!)
-        request1.HTTPMethod = "POST"
+        var request1 = URLRequest(url: URL(string: "http://random.com")!)
+        request1.httpMethod = "POST"
         
-        let request2 = NSMutableURLRequest(URL: NSURL(string: "http://random.com/random")!)
-        request2.HTTPMethod = "DELETE"
+        var request2 = URLRequest(url: URL(string: "http://random.com/random")!)
+        request2.httpMethod = "DELETE"
         
-        let request3 = NSMutableURLRequest(URL: NSURL(string: "http://random.com/random/another/one")!)
-        request2.HTTPMethod = "PUT"
+        var request3 = URLRequest(url: URL(string: "http://random.com/random/another/one")!)
+        request3.httpMethod = "PUT"
         
-        let checker: (NSData?, NSURLResponse?, NSError?) -> () = { (taskData, response, anError) in
+        let checker: (Data?, URLResponse?, Error?) -> () = { (taskData, response, anError) in
             
-            guard let httpResponse = response as? NSHTTPURLResponse else {
+            guard let httpResponse = response as? HTTPURLResponse else {
                 fatalError("response should be a `NSHTTPURLResponse`")
             }
             
@@ -324,9 +324,9 @@ class TurntableTests: XCTestCase {
                     XCTAssertTrue(responseHeaders == originalHeaders)
                 }
                 
-                XCTAssertTrue(httpResponse.URL == track.response.urlResponse?.URL)
+                XCTAssertTrue(httpResponse.url == track.response.urlResponse?.url)
                 
-                tracks.removeAtIndex(tracks.indexOf(track)!)
+                tracks.remove(at: tracks.index(of: track)!)
             }
             
             if tracks.isEmpty {
@@ -336,142 +336,142 @@ class TurntableTests: XCTestCase {
         
         let turntable = Turntable(
             vinyl: Vinyl(tracks: tracks),
-            turntableConfiguration: TurntableConfiguration(matchingStrategy: .TrackOrder))
+            turntableConfiguration: TurntableConfiguration(matchingStrategy: .trackOrder))
         
-        turntable.dataTaskWithRequest(request1, completionHandler: checker).resume()
-        turntable.dataTaskWithRequest(request2, completionHandler: checker).resume()
-        turntable.dataTaskWithRequest(request3, completionHandler: checker).resume()
+        turntable.dataTask(with: request1, completionHandler: checker).resume()
+        turntable.dataTask(with: request2, completionHandler: checker).resume()
+        turntable.dataTask(with: request3, completionHandler: checker).resume()
     }
     
     //MARK: - Delegate queue
     
     func test_Vinyl_defaultQueue() {
         
-        let expectation = self.expectationWithDescription("Expected callback to be called on background thread")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "Expected callback to be called on background thread")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
         let turntable = Turntable(vinylName: "vinyl_single")
         
         let urlString = "http://api.test.com"
         
-        turntable.dataTaskWithURL(NSURL(string: urlString)!) { (data, response, anError) in
+        turntable.dataTask(with: URL(string: urlString)!, completionHandler: { (data, response, anError) in
             
-            XCTAssertFalse(NSThread.isMainThread())
+            XCTAssertFalse(Thread.isMainThread)
             expectation.fulfill()
-            }.resume()
+            }) .resume()
     }
     
     func test_Vinyl_mainQueue() {
         
-        let expectation = self.expectationWithDescription("Expected callback to be called on main thread")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "Expected callback to be called on main thread")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
-        let turntable = Turntable(vinylName: "vinyl_single", delegateQueue: NSOperationQueue.mainQueue())
+        let turntable = Turntable(vinylName: "vinyl_single", delegateQueue: OperationQueue.main)
         
         let urlString = "http://api.test.com"
         
-        turntable.dataTaskWithURL(NSURL(string: urlString)!) { (data, response, anError) in
+        turntable.dataTask(with: URL(string: urlString)!, completionHandler: { (data, response, anError) in
             
-            XCTAssertTrue(NSThread.isMainThread())
+            XCTAssertTrue(Thread.isMainThread)
             expectation.fulfill()
-            }.resume()
+            }) .resume()
     }
     
     func test_Vinyl_Delegate() {
         
-        let turntable = Turntable(vinylName: "vinyl_single", delegateQueue: NSOperationQueue.mainQueue())
+        let turntable = Turntable(vinylName: "vinyl_single", delegateQueue: OperationQueue.main)
         XCTAssertNil(turntable.delegate)
     }
     
     func test_Vinyl_recording_missingVinyl_vinylMissing() {
-        let expectation = self.expectationWithDescription("Expected callback to be called on background thread")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "Expected callback to be called on background thread")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
         let recordingVinylName = "vinyl_recording"
         let path = prepPathForRecording(recordingVinylName)
         
         let dogFood = Turntable(vinylName: "vinyl_single")
         let turntable = Turntable(vinylName: recordingVinylName,
-                                  turntableConfiguration: TurntableConfiguration(recordingMode: .MissingVinyl(recordingPath: nil)),
+                                  turntableConfiguration: TurntableConfiguration(recordingMode: .missingVinyl(recordingPath: nil)),
                                   urlSession: dogFood)
         
         let urlString = "http://api.test.com"
         
-        turntable.dataTaskWithURL(NSURL(string: urlString)!) { (data, response, anError) in
+        turntable.dataTask(with: URL(string: urlString)!, completionHandler: { (data, response, anError) in
             turntable.stopRecording()
             
-            XCTAssertTrue(NSFileManager.defaultManager().fileExistsAtPath(path))
+            XCTAssertTrue(FileManager.default.fileExists(atPath: path))
             
             expectation.fulfill()
-            }.resume()
+            }) .resume()
     }
 
     func test_Vinyl_recording_missingVinyl_vinylPresent() {
-        let expectation = self.expectationWithDescription("Expected callback to be called on background thread")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "Expected callback to be called on background thread")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
         let recordingVinylName = "vinyl_recording"
         let path = prepPathForRecording(recordingVinylName)
         
         let dogFood = Turntable(vinylName: "vinyl_single")
         let turntable = Turntable(vinylName: "vinyl_single",
-                                  turntableConfiguration: TurntableConfiguration(recordingMode: .MissingVinyl(recordingPath: nil)),
+                                  turntableConfiguration: TurntableConfiguration(recordingMode: .missingVinyl(recordingPath: nil)),
                                   urlSession: dogFood)
         
         let urlString = "http://api.test.com"
         
-        turntable.dataTaskWithURL(NSURL(string: urlString)!) { (data, response, anError) in
+        turntable.dataTask(with: URL(string: urlString)!, completionHandler: { (data, response, anError) in
             turntable.stopRecording()
             
-            XCTAssertFalse(NSFileManager.defaultManager().fileExistsAtPath(path))
+            XCTAssertFalse(FileManager.default.fileExists(atPath: path))
             
             expectation.fulfill()
-            }.resume()
+            }) .resume()
     }
 
     func test_Vinyl_recording_missingTracks_missingTrack() {
-        let expectation = self.expectationWithDescription("Expected callback to be called on background thread")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "Expected callback to be called on background thread")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
         let recordingVinylName = "vinyl_recording"
         let path = prepPathForRecording(recordingVinylName)
         
         let dogFood = Turntable(vinylName: "vinyl_multiple")
         let turntable = Turntable(vinylName: "vinyl_single",
-                                  turntableConfiguration: TurntableConfiguration(recordingMode: .MissingTracks(recordingPath: path)),
+                                  turntableConfiguration: TurntableConfiguration(recordingMode: .missingTracks(recordingPath: path)),
                                   urlSession: dogFood)
         
         let urlString = "http://api.test1.com"
         
-        turntable.dataTaskWithURL(NSURL(string: urlString)!) { (data, response, anError) in
+        turntable.dataTask(with: URL(string: urlString)!, completionHandler: { (data, response, anError) in
             turntable.stopRecording()
             
-            XCTAssertTrue(NSFileManager.defaultManager().fileExistsAtPath(path))
+            XCTAssertTrue(FileManager.default.fileExists(atPath: path))
             
             expectation.fulfill()
-            }.resume()
+            }) .resume()
     }
 
     func test_Vinyl_recording_missingTracks_existingTrack() {
-        let expectation = self.expectationWithDescription("Expected callback to be called on background thread")
-        defer { self.waitForExpectationsWithTimeout(4, handler: nil) }
+        let expectation = self.expectation(description: "Expected callback to be called on background thread")
+        defer { self.waitForExpectations(timeout: 4, handler: nil) }
         
         let recordingVinylName = "vinyl_recording"
         let path = prepPathForRecording(recordingVinylName)
         
         let dogFood = Turntable(vinylName: "vinyl_single")
         let turntable = Turntable(vinylName: "vinyl_single",
-                                  turntableConfiguration: TurntableConfiguration(recordingMode: .MissingTracks(recordingPath: path)),
+                                  turntableConfiguration: TurntableConfiguration(recordingMode: .missingTracks(recordingPath: path)),
                                   urlSession: dogFood)
         
         let urlString = "http://api.test.com"
         
-        turntable.dataTaskWithURL(NSURL(string: urlString)!) { (data, response, anError) in
+        turntable.dataTask(with: URL(string: urlString)!, completionHandler: { (data, response, anError) in
             turntable.stopRecording()
             
-            XCTAssertFalse(NSFileManager.defaultManager().fileExistsAtPath(path))
+            XCTAssertFalse(FileManager.default.fileExists(atPath: path))
             
             expectation.fulfill()
-            }.resume()
+            }) .resume()
     }
 }


### PR DESCRIPTION
Everything has been migrated to Swift 3. Tests are passing.

SwiftCheck was removed as a git submodule and made a regular Carthage dependency and added as a linked framework for the test targets.

No function names were changed to match the new Swift naming style, but this could be added to the PR.