### PR TITLE
Add configuration override

### DIFF
--- a/Vinyl/Turntable.swift
+++ b/Vinyl/Turntable.swift
@@ -155,6 +155,14 @@ public final class Turntable: URLSession {
 
 extension Turntable {
     
+    public override var configuration: URLSessionConfiguration {
+        if let session = recordingSession {
+            return session.configuration
+        } else {
+            return URLSessionConfiguration.default
+        }
+    }
+    
     public override func dataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> Foundation.URLSessionDataTask {
         let request = URLRequest(url: url)
         return dataTask(with: request, completionHandler: completionHandler)

--- a/VinylTests/TurntableTests.swift
+++ b/VinylTests/TurntableTests.swift
@@ -474,4 +474,27 @@ class TurntableTests: XCTestCase {
             expectation.fulfill()
             }) .resume()
     }
+
+    func test_default_URLSession_configuration() {
+        let turntable = Turntable(vinylName: "vinyl_single")
+
+        // If this doesn't crash we pass
+        let _ = turntable.configuration
+    }
+
+    func test_recording_URLSession_configuration() {
+        let expectedHeaderValue = "Vinyl"
+        let configuration = URLSessionConfiguration.default
+        configuration.httpAdditionalHeaders = ["X-UniqueHeader": expectedHeaderValue]
+
+        let urlSession = URLSession(configuration: configuration)
+        let turntable = Turntable(vinylName: "vinyl_single",
+                                  turntableConfiguration: TurntableConfiguration(recordingMode: .missingTracks(recordingPath: nil)),
+                                  urlSession: urlSession)
+
+        let headerValue = turntable.configuration.httpAdditionalHeaders!["X-UniqueHeader"] as! String
+
+        // Can't compare `configuration` instances since they return copies
+        XCTAssertEqual(headerValue, expectedHeaderValue)
+    }
 }


### PR DESCRIPTION
Without this override accessing `configuration` will crash with `-[Vinyl.Turntable _local_immutable_configuration]: unrecognized selector sent to instance`.