### PR TITLE
returning right delegate

### DIFF
--- a/Vinyl/Turntable.swift
+++ b/Vinyl/Turntable.swift
@@ -147,7 +147,7 @@ public final class Turntable: URLSession {
     }
     
     public override var delegate: URLSessionDelegate? {
-        return nil
+        return recordingSession?.delegate
     }
 }
 


### PR DESCRIPTION
i think this might have been overlooked - there is no way to create an Alamofire.SessionManager ala the docs unless the internal session delegate is being returned.