### PR TITLE
Added matcher for host

### DIFF
--- a/Vinyl/RequestMatcherRegistry.swift
+++ b/Vinyl/RequestMatcherRegistry.swift
@@ -11,6 +11,7 @@ import Foundation
 public enum RequestMatcherType {
     case method
     case url
+    case host
     case path
     case query
     case headers
@@ -42,6 +43,8 @@ public struct RequestMatcherRegistry {
             return MethodRequestMatcher()
         case .url:
             return URLRequestMatcher()
+        case .host:
+            return HostRequestMatcher()
         case .path:
             return PathRequestMatcher()
         case .query:
@@ -65,13 +68,19 @@ private struct MethodRequestMatcher: RequestMatcher {
     }
 }
 
-private  struct URLRequestMatcher: RequestMatcher {
+private struct URLRequestMatcher: RequestMatcher {
     func match(lhs: Request, rhs: Request) -> Bool {
         return lhs.url == rhs.url
     }
 }
 
-private  struct PathRequestMatcher: RequestMatcher {
+private struct HostRequestMatcher: RequestMatcher {
+    func match(lhs: Request, rhs: Request) -> Bool {
+        return lhs.url?.host == rhs.url?.host
+    }
+}
+
+private struct PathRequestMatcher: RequestMatcher {
     func match(lhs: Request, rhs: Request) -> Bool {
         return lhs.url?.path == rhs.url?.path
     }

--- a/VinylTests/Arbitrary.swift
+++ b/VinylTests/Arbitrary.swift
@@ -88,6 +88,26 @@ let pathParameterGen: Gen<String> = pathParameterGenArray.map { xs in
     }
 }
 
+func pathParameterGenArrayMinimumSize(_ minimumSize: Int) -> Gen<[String]> {
+    return Gen.sized { sz in
+        return parameterGen.proliferate(withSize: max(sz + 1, minimumSize))
+    }
+}
+
+func pathParameterGenMinimumSize(_ minimumSize: Int) -> Gen<String> {
+    return pathParameterGenArrayMinimumSize(minimumSize).map { xs in
+        return xs.reduce("?") {
+            switch $0 {
+            case "?":
+                return $0 + $1
+            default:
+                return $0 + "&" + $1
+            }
+        }
+    }
+}
+
+
 private func curry<A, B, C>(_ f : @escaping (A, B) -> C) -> (A) -> (B) -> C {
     return { a in { b in f(a, b) } }
 }


### PR DESCRIPTION
When order of query parameters is not consistent url matcher will fail as it compares the whole url. To be able to match in this case host, path and query parameters should be matched separately, so this PR adds matcher just for host.