### PR TITLE
Expose ErrorHandler protocol; inject errorHandler into Turntable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9.4
+osx_image: xcode10.2
 env:
   matrix:
     - PLATFORM="iOS"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "typelift/SwiftCheck" "0.10.0"
+github "typelift/SwiftCheck" "0.12.0"

--- a/Vinyl/ErrorHandler/ErrorHandler.swift
+++ b/Vinyl/ErrorHandler/ErrorHandler.swift
@@ -8,14 +8,16 @@
 
 import Foundation
 
-protocol ErrorHandler {
+public protocol ErrorHandler {
     func handleTrackNotFound(_ request: Request, playTracksUniquely: Bool)
     func handleUnknownError()
 }
 
-struct DefaultErrorHandler: ErrorHandler {
-    
-    func handleTrackNotFound(_ request: Request, playTracksUniquely: Bool) {
+public struct DefaultErrorHandler: ErrorHandler {
+
+    public init() {}
+
+    public func handleTrackNotFound(_ request: Request, playTracksUniquely: Bool) {
      
         if playTracksUniquely {
             fatalError("💥 No 🎶 recorded and matchable with request: \n\(request.debugDescription)\n\nThis might be happening because you are trying to consume the same request multiple times 😩\n")
@@ -25,7 +27,7 @@ struct DefaultErrorHandler: ErrorHandler {
         }
     }
     
-    func handleUnknownError() {
+    public func handleUnknownError() {
         fatalError("💥")
     }
 }

--- a/Vinyl/Turntable.swift
+++ b/Vinyl/Turntable.swift
@@ -54,11 +54,12 @@ public final class Turntable: URLSession {
         self.init(vinyl: vinyl, turntableConfiguration: turntableConfiguration, delegateQueue: delegateQueue, urlSession: urlSession)
     }
     
-    public convenience init(vinylName: String, bundle: Bundle = testingBundle(), turntableConfiguration: TurntableConfiguration = TurntableConfiguration(), delegateQueue: OperationQueue? = nil, urlSession: URLSession? = nil) {
+    public convenience init(vinylName: String, bundle: Bundle = testingBundle(), turntableConfiguration: TurntableConfiguration = TurntableConfiguration(), delegateQueue: OperationQueue? = nil, urlSession: URLSession? = nil, errorHandler: ErrorHandler = DefaultErrorHandler()) {
         let plastic = Turntable.createPlastic(vinyl: vinylName, bundle: bundle, recordingMode: turntableConfiguration.recordingMode)
         let vinyl = Vinyl(plastic: plastic ?? [])
         self.init(vinyl: vinyl, turntableConfiguration: turntableConfiguration, delegateQueue: delegateQueue, urlSession: urlSession)
-        
+
+        self.errorHandler = errorHandler
         switch turntableConfiguration.recordingMode {
         case .missingVinyl where plastic == nil, .missingTracks:
             recorder = Recorder(wax: Wax(vinyl: vinyl), recordingPath: recordingPath(fromConfiguration: turntableConfiguration, vinylName: vinylName, bundle: bundle))


### PR DESCRIPTION
- Bumping Xcode to 10.2
- Exposing ErrorHandling protocol and injecting errorHandler into Turntable. This might be useful if custom handling is required, for example, you might want to fail current test if a request wasn't found. This change doesn't introduce breaking changes.

```Swift
struct ReplayErrorHandler: ErrorHandler {
    func handleTrackNotFound(_ request: Request, playTracksUniquely: Bool) {
        XCTFail("Record not found: \(request)")
    }

    func handleUnknownError() {
        XCTFail("Unknown error")
    }
}
```